### PR TITLE
style: prevent linked whitespace in footer

### DIFF
--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -127,7 +127,7 @@ const links = [
     <footer class="py-6 md:px-8 md:py-0">
       <div class="container flex flex-col items-center justify-between gap-4 md:h-24 md:flex-row">
         <div class="text-center text-sm leading-loose text-muted-foreground md:text-left">
-          <span class="text-sm">
+          <span class="inline-block">
             Built and designed by
             <a
               href="https://twitter.com/shadcn"
@@ -137,8 +137,8 @@ const links = [
               shadcn
             </a>
           </span>
-          <span class="text-sm ml-0.5"> . </span>
-          <span class="text-sm ml-2">
+          <span class="ml-0.5"> . </span>
+          <span class="inline-block ml-2">
             Ported to Vue by
             <a
               href="https://twitter.com"
@@ -148,8 +148,8 @@ const links = [
               Radix Vue
             </a>
           </span>
-          <span class="text-sm ml-0.5"> . </span>
-          <span class="text-sm ml-2">
+          <span class="ml-0.5"> . </span>
+          <span class="inline-block ml-2">
             The code source is available on
             <a
               href="https://github.com/radix-vue/shadcn-vue"


### PR DESCRIPTION
An alternative solution would be to leave the texts on one line in the source. However, I did not want to change the structure of your code too much here, hence `inline-block`. I also removed the superfluous `text-sm` classes, as this size is already set in the parent element.

#### Before
![before](https://github.com/radix-vue/shadcn-vue/assets/13335308/ba06d065-fa06-45f0-a49c-46f309166f5b)

#### After
![after](https://github.com/radix-vue/shadcn-vue/assets/13335308/d7630766-030c-478c-abd8-ae7a1173c9da)