### PR TITLE
docs: fix link

### DIFF
--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -141,7 +141,7 @@ const links = [
           <span class="inline-block ml-2">
             Ported to Vue by
             <a
-              href="https://twitter.com"
+              href="https://github.com/radix-vue"
               target="_blank"
               class="underline underline-offset-4 font-bold decoration-foreground"
             >


### PR DESCRIPTION
This PR:

- [x] Fixes a link in the docs footer

I took the liberty to link to the GitHub organization because I could not find a Twitter/X account to link to.