### PR TITLE
fix(cli): should move `detype` to `dependencies`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "chalk": "5.3.0",
     "commander": "^11.0.0",
     "cosmiconfig": "^8.3.6",
+    "detype": "^0.6.3",
     "diff": "^5.1.0",
     "execa": "^8.0.1",
     "fs-extra": "^11.1.1",
@@ -76,7 +77,6 @@
     "@types/lodash.template": "^4.5.1",
     "@types/prompts": "^2.4.4",
     "@vitest/ui": "^0.34.4",
-    "detype": "^0.6.3",
     "tsup": "^7.2.0",
     "type-fest": "^4.3.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
fix: #60

The `detype` are dependencies that will be used at runtime