### PR TITLE
fix(components): add emits to the tabs component

### DIFF
--- a/apps/www/src/lib/registry/default/ui/tabs/Tabs.vue
+++ b/apps/www/src/lib/registry/default/ui/tabs/Tabs.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
-import { TabsRoot, type TabsRootProps } from 'radix-vue'
+import { useForwardPropsEmits } from 'radix-vue'
+import type { TabsRootEmits, TabsRootProps } from 'radix-vue'
 
 const props = defineProps<TabsRootProps>()
+const emits = defineEmits<TabsRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
 </script>
 
 <template>
-  <TabsRoot v-bind="props">
+  <TabsRoot v-bind="forwarded">
     <slot />
   </TabsRoot>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/tabs/Tabs.vue
+++ b/apps/www/src/lib/registry/new-york/ui/tabs/Tabs.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
-import { TabsRoot, type TabsRootProps } from 'radix-vue'
+import { useForwardPropsEmits } from 'radix-vue'
+import type { TabsRootEmits, TabsRootProps } from 'radix-vue'
 
 const props = defineProps<TabsRootProps>()
+const emits = defineEmits<TabsRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
 </script>
 
 <template>
-  <TabsRoot v-bind="props">
+  <TabsRoot v-bind="forwarded">
     <slot />
   </TabsRoot>
 </template>

--- a/apps/www/src/public/registry/styles/default/tabs.json
+++ b/apps/www/src/public/registry/styles/default/tabs.json
@@ -9,7 +9,7 @@
   "files": [
     {
       "name": "Tabs.vue",
-      "content": "<script setup lang=\"ts\">\nimport { TabsRoot, type TabsRootProps } from 'radix-vue'\n\nconst props = defineProps<TabsRootProps>()\n</script>\n\n<template>\n  <TabsRoot v-bind=\"props\">\n    <slot />\n  </TabsRoot>\n</template>\n"
+      "content": "<script setup lang=\"ts\">\nimport { useForwardPropsEmits } from 'radix-vue'\nimport type { TabsRootEmits, TabsRootProps } from 'radix-vue'\n\nconst props = defineProps<TabsRootProps>()\nconst emits = defineEmits<TabsRootEmits>()\n\nconst forwarded = useForwardPropsEmits(props, emits)\n</script>\n\n<template>\n  <TabsRoot v-bind=\"forwarded\">\n    <slot />\n  </TabsRoot>\n</template>\n"
     },
     {
       "name": "TabsContent.vue",

--- a/apps/www/src/public/registry/styles/new-york/tabs.json
+++ b/apps/www/src/public/registry/styles/new-york/tabs.json
@@ -9,7 +9,7 @@
   "files": [
     {
       "name": "Tabs.vue",
-      "content": "<script setup lang=\"ts\">\nimport { TabsRoot, type TabsRootProps } from 'radix-vue'\n\nconst props = defineProps<TabsRootProps>()\n</script>\n\n<template>\n  <TabsRoot v-bind=\"props\">\n    <slot />\n  </TabsRoot>\n</template>\n"
+      "content": "<script setup lang=\"ts\">\nimport { useForwardPropsEmits } from 'radix-vue'\nimport type { TabsRootEmits, TabsRootProps } from 'radix-vue'\n\nconst props = defineProps<TabsRootProps>()\nconst emits = defineEmits<TabsRootEmits>()\n\nconst forwarded = useForwardPropsEmits(props, emits)\n</script>\n\n<template>\n  <TabsRoot v-bind=\"forwarded\">\n    <slot />\n  </TabsRoot>\n</template>\n"
     },
     {
       "name": "TabsContent.vue",


### PR DESCRIPTION
I noticed that the `Tabs` component doesn't forward the emits from the `TabsRoot` component of `radix-vue`.