### PR TITLE
Update select.md with correct docs link to select component

### DIFF
--- a/apps/www/src/content/docs/components/select.md
+++ b/apps/www/src/content/docs/components/select.md
@@ -1,8 +1,8 @@
 ---
 title: Select
 description: Displays a list of options for the user to pick from—triggered by a button.
-source: apps/www/src/lib/registry/default/ui/popover 
-primitive: https://www.radix-vue.com/components/popover.html
+source: apps/www/src/lib/registry/default/ui/select 
+primitive: https://www.radix-vue.com/components/select.html
 ---
 
 


### PR DESCRIPTION
The link to vue-shadcn source & radix-vue docs was pointing to Popover component instead of Select component.

Not sure why it sees line 48 as a diff though?