### PR TITLE
docs: fix `DataTableDemo` repro links fix `new-york` style

### DIFF
--- a/apps/www/.vitepress/theme/components/CodeSandbox.vue
+++ b/apps/www/.vitepress/theme/components/CodeSandbox.vue
@@ -9,6 +9,7 @@ import { type Style } from '@/lib/registry/styles'
 const props = defineProps<{
   name: string
   code: string
+  newYorkCode: string
   style: Style
   extraFiles?: string[]
 }>()
@@ -16,7 +17,7 @@ const props = defineProps<{
 const sources = ref<Record<string, string>>({})
 
 onMounted(() => {
-  sources.value['App.vue'] = props.code
+  sources.value['App.vue'] = props.style === 'default' ? props.code : props.newYorkCode
   if (props.extraFiles) {
     props.extraFiles.forEach((file) => {
       import(`../../../src/lib/registry/${props.style}/example/${file}.vue?raw`).then((module) => {

--- a/apps/www/.vitepress/theme/components/CodeSandbox.vue
+++ b/apps/www/.vitepress/theme/components/CodeSandbox.vue
@@ -10,12 +10,20 @@ const props = defineProps<{
   name: string
   code: string
   style: Style
+  extraFiles?: string[]
 }>()
 
 const sources = ref<Record<string, string>>({})
 
 onMounted(() => {
   sources.value['App.vue'] = props.code
+  if (props.extraFiles) {
+    props.extraFiles.forEach((file) => {
+      import(`../../../src/lib/registry/${props.style}/example/${file}.vue?raw`).then((module) => {
+        sources.value[`${file}.vue`] = module.default
+      })
+    })
+  }
 })
 </script>
 

--- a/apps/www/.vitepress/theme/components/ComponentPreview.vue
+++ b/apps/www/.vitepress/theme/components/ComponentPreview.vue
@@ -12,6 +12,7 @@ const props = withDefaults(defineProps<{
   align?: 'center' | 'start' | 'end'
   sfcTsCode?: string
   sfcTsHtml?: string
+  extraFiles?: string[]
 }>(), { align: 'center' })
 
 const { style } = useConfigStore()
@@ -43,8 +44,8 @@ const { style } = useConfigStore()
           <StyleSwitcher />
 
           <div class="flex items-center gap-x-1">
-            <Stackblitz :key="style" :style="style" :name="name" :code="decodeURIComponent(sfcTsCode ?? '')" />
-            <CodeSandbox :key="style" :style="style" :name="name" :code="decodeURIComponent(sfcTsCode ?? '')" />
+            <Stackblitz :key="style" :extra-files="extraFiles" :style="style" :name="name" :code="decodeURIComponent(sfcTsCode ?? '')" />
+            <CodeSandbox :key="style" :extra-files="extraFiles" :style="style" :name="name" :code="decodeURIComponent(sfcTsCode ?? '')" />
           </div>
         </div>
         <div

--- a/apps/www/.vitepress/theme/components/ComponentPreview.vue
+++ b/apps/www/.vitepress/theme/components/ComponentPreview.vue
@@ -11,6 +11,7 @@ const props = withDefaults(defineProps<{
   name: string
   align?: 'center' | 'start' | 'end'
   sfcTsCode?: string
+  sfcTsNewYorkCode?: string
   sfcTsHtml?: string
   extraFiles?: string[]
 }>(), { align: 'center' })
@@ -44,8 +45,8 @@ const { style } = useConfigStore()
           <StyleSwitcher />
 
           <div class="flex items-center gap-x-1">
-            <Stackblitz :key="style" :extra-files="extraFiles" :style="style" :name="name" :code="decodeURIComponent(sfcTsCode ?? '')" />
-            <CodeSandbox :key="style" :extra-files="extraFiles" :style="style" :name="name" :code="decodeURIComponent(sfcTsCode ?? '')" />
+            <Stackblitz :key="style" :extra-files="extraFiles" :style="style" :name="name" :code="decodeURIComponent(sfcTsCode ?? '')" :new-york-code="decodeURIComponent(sfcTsNewYorkCode ?? '')" />
+            <CodeSandbox :key="style" :extra-files="extraFiles" :style="style" :name="name" :code="decodeURIComponent(sfcTsCode ?? '')" :new-york-code="decodeURIComponent(sfcTsNewYorkCode ?? '')" />
           </div>
         </div>
         <div

--- a/apps/www/.vitepress/theme/components/Stackblitz.vue
+++ b/apps/www/.vitepress/theme/components/Stackblitz.vue
@@ -9,6 +9,7 @@ import { type Style } from '@/lib/registry/styles'
 const props = defineProps<{
   name: string
   code: string
+  newYorkCode: string
   style: Style
   extraFiles?: string[]
 }>()
@@ -16,7 +17,7 @@ const props = defineProps<{
 const sources = ref<Record<string, string>>({})
 
 onMounted(() => {
-  sources.value['App.vue'] = props.code
+  sources.value['App.vue'] = props.style === 'default' ? props.code : props.newYorkCode
   if (props.extraFiles) {
     props.extraFiles.forEach((file) => {
       import(`../../../src/lib/registry/${props.style}/example/${file}.vue?raw`).then((module) => {

--- a/apps/www/.vitepress/theme/components/Stackblitz.vue
+++ b/apps/www/.vitepress/theme/components/Stackblitz.vue
@@ -10,12 +10,20 @@ const props = defineProps<{
   name: string
   code: string
   style: Style
+  extraFiles?: string[]
 }>()
 
 const sources = ref<Record<string, string>>({})
 
 onMounted(() => {
   sources.value['App.vue'] = props.code
+  if (props.extraFiles) {
+    props.extraFiles.forEach((file) => {
+      import(`../../../src/lib/registry/${props.style}/example/${file}.vue?raw`).then((module) => {
+        sources.value[`${file}.vue`] = module.default
+      })
+    })
+  }
 })
 
 function handleClick() {

--- a/apps/www/.vitepress/theme/plugins/previewer.ts
+++ b/apps/www/.vitepress/theme/plugins/previewer.ts
@@ -18,6 +18,7 @@ export default function (md: MarkdownRenderer) {
       const { name, attrs } = props
       const pluginPath = dirname(__dirname)
       const srcPath = resolve(pluginPath, '../../src/lib/registry/default/example/', `${name}.vue`).replace(/\\/g, '/')
+      const srcPathNewYork = resolve(pluginPath, '../../src/lib/registry/new-york/example/', `${name}.vue`).replace(/\\/g, '/')
 
       if (!fs.existsSync(srcPath)) {
         console.error(`rendering ${path}: ${srcPath} does not exist`)
@@ -28,6 +29,7 @@ export default function (md: MarkdownRenderer) {
         attrs,
         props,
         code: fs.readFileSync(srcPath, 'utf-8'),
+        newYorkCode: fs.readFileSync(srcPathNewYork, 'utf-8'),
         path: srcPath,
       })
 

--- a/apps/www/.vitepress/theme/plugins/utils.ts
+++ b/apps/www/.vitepress/theme/plugins/utils.ts
@@ -9,18 +9,20 @@ export interface GenerateOptions {
   props: Record<string, any>
   path: string
   code: string
+  newYorkCode: string
 }
 
 export function parse(
   md: MarkdownRenderer,
   env: MarkdownEnv,
-  { code, attrs: _attrs, props }: GenerateOptions,
+  { newYorkCode, code, attrs: _attrs, props }: GenerateOptions,
 ) {
   const highlightedHtml = md.options.highlight!(code, 'vue', _attrs || '')
   const sfcTsHtml = highlightedHtml
 
   const attrs
    = `sfcTsCode="${encodeURIComponent(code)}"\n`
+   + `sfcTsNewYorkCode="${encodeURIComponent(newYorkCode)}"\n`
    + `sfcTsHtml="${encodeURIComponent(sfcTsHtml)}"\n`
    + `v-bind='${JSON.stringify(props)}'\n`
 

--- a/apps/www/.vitepress/theme/utils/codeeditor.ts
+++ b/apps/www/.vitepress/theme/utils/codeeditor.ts
@@ -75,8 +75,10 @@ function constructFiles(componentName: string, style: Style, sources: Record<str
     },
   }
 
+  const isDataTableDemo = componentName.includes('DataTable')
   const iconPackage = style === 'default' ? 'lucide-vue-next' : '@radix-icons/vue'
   const dependencies = {
+    '@vueuse/core': 'latest',
     'vue': 'latest',
     'radix-vue': deps['radix-vue'],
     '@radix-ui/colors': 'latest',
@@ -88,6 +90,8 @@ function constructFiles(componentName: string, style: Style, sources: Record<str
     'shadcn-vue': 'latest',
     'typescript': 'latest',
   }
+  if (isDataTableDemo)
+    dependencies['@tanstack/vue-table'] = 'latest'
 
   const devDependencies = {
     'vite': 'latest',
@@ -97,6 +101,29 @@ function constructFiles(componentName: string, style: Style, sources: Record<str
     'postcss': 'latest',
     'autoprefixer': 'latest',
   }
+
+  const baseUtilsString = `import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+import { camelize, getCurrentInstance, toHandlerKey } from 'vue'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))`
+
+  const baseUtilsStringWithUpdater = `import type { Updater } from '@tanstack/vue-table'
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+import { type Ref, camelize, getCurrentInstance, toHandlerKey } from 'vue'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+export function valueUpdater<T extends Updater<any>>(updaterOrValue: T, ref: Ref) {
+  ref.value
+    = typeof updaterOrValue === 'function'
+      ? updaterOrValue(ref.value)
+      : updaterOrValue
+}`
 
   const transformImportPath = (code: string) => {
     let parsed = code
@@ -159,13 +186,7 @@ function constructFiles(componentName: string, style: Style, sources: Record<str
     },
     'src/utils.ts': {
       isBinary: false,
-      content: `import { type ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
-import { camelize, getCurrentInstance, toHandlerKey } from 'vue'
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}`,
+      content: isDataTableDemo ? baseUtilsStringWithUpdater : baseUtilsString,
     },
     'src/assets/index.css': {
       content: cssRaw,

--- a/apps/www/src/content/docs/components/data-table.md
+++ b/apps/www/src/content/docs/components/data-table.md
@@ -4,7 +4,7 @@ description: Powerful table and datagrids built using TanStack Table.
 ---
 
 
-<ComponentPreview name="DataTableDemo"  /> 
+<ComponentPreview name="DataTableDemo" :extra-files='["DataTableDemoColumn"]' /> 
 
 ## Introduction
 


### PR DESCRIPTION
https://www.shadcn-vue.com/docs/components/data-table.html

The way you handle the components with the start command is so nice 😮 
I did it manually in (.vitepress/theme/plugins/utils|previewer.ts) with base config lol

---

BTW this PR will fix DataTableDemo and new-york code in reproduction buttons