### PR TITLE
docs: fix `nuxt.config.ts` configuration for auto-import components directories

### DIFF
--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -46,7 +46,9 @@ export default defineNuxtConfig({
         // this is required else Nuxt will autoImport `.ts` file
         extensions: ['.vue'],
         // prefix for your components, eg: UiButton
-        prefix: 'Ui'
+        prefix: 'Ui',
+        // prevent adding another prefix component by it's path.
+        pathPrefix: false
       })
     }
   }

--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -28,22 +28,30 @@ npm install -D @nuxtjs/tailwindcss
 
 ### Configure `nuxt.config.ts`
 
+<Callout class="mt-4">
+
+**Tip:** It's better to use Nuxt `components:dirs` hook to extend auto-import components directories. 
+
+If you use `components` key in `nuxt.config.ts` default config will disposed
+
+</Callout>
+
 ```ts
 export default defineNuxtConfig({
   modules: ['@nuxtjs/tailwindcss'],
-  components: [
-    {
-      path: '~/components/ui',
-      // this is required else Nuxt will autoImport `.ts` file
-      extensions: ['.vue'],
-      // prefix for your components, eg: UiButton
-      prefix: 'Ui'
-    },
-  ],
+  hooks: {
+    'components:dirs': (dirs) => {
+      dirs.unshift({
+        path: '~/components/ui',
+        // this is required else Nuxt will autoImport `.ts` file
+        extensions: ['.vue'],
+        // prefix for your components, eg: UiButton
+        prefix: 'Ui'
+      })
+    }
+  }
 })
 ```
-
-
 
 ### Run the CLI
 


### PR DESCRIPTION
Resolve #153 

If we use the `components` key in the `nuxt.config.ts` default config for directories will **removed**

default configs 👇 

```
{ priority: 1, path: 'D:/Test/nuxt-test/components/islands', island: true },
{ priority: 1, path: 'D:/Test/nuxt-test/components/global', global: true },
{ priority: 1, path: 'D:/Test/nuxt-test/components' },
```

Instead, it's better to use `components:dirs` hook for extending auto-import directories