### PR TITLE
docs(app): add shadcn/vue VSCode extension

### DIFF
--- a/apps/www/.vitepress/theme/config/site.ts
+++ b/apps/www/.vitepress/theme/config/site.ts
@@ -15,6 +15,6 @@ export const siteConfig = {
 
 export const announcementConfig = {
   icon: '✨',
-  title: 'New Toast component',
-  link: '/docs/components/toast',
+  title: 'VSCode extension',
+  link: '/docs/installation.html#vscode-extension',
 }

--- a/apps/www/src/content/docs/installation.md
+++ b/apps/www/src/content/docs/installation.md
@@ -97,4 +97,11 @@ To configure import aliases, you can use the following `jsconfig.json`:
 
 ## VSCode extension
 
-Install the [shadcn-vue](https://marketplace.visualstudio.com/items?itemName=Selemondev.shadcn-vue) extension in Visual Studio Code to easily add Shadcn Vue components to your project. This extension offers a range of features, including the ability to initialize the Shadcn Vue CLI, install components, open Shadcn Vue docs, and navigate to a specific component's documentation page directly from your IDE. Additionally, it comes with handy snippets for quick and straightforward component imports and markup.
+Install the [shadcn-vue](https://marketplace.visualstudio.com/items?itemName=Selemondev.shadcn-vue) extension by [@selemondev](https://github.com/selemondev) in Visual Studio Code to easily add Shadcn Vue components to your project. 
+
+This extension offers a range of features:
+- Ability to initialize the Shadcn Vue CLI
+- Install components
+- Open documentation
+- Navigate to a specific component's documentation page directly from your IDE. 
+- Handy snippets for quick and straightforward component imports and markup.

--- a/apps/www/src/content/docs/installation.md
+++ b/apps/www/src/content/docs/installation.md
@@ -93,3 +93,8 @@ To configure import aliases, you can use the following `jsconfig.json`:
     }
   }
 }
+```
+
+## VSCode extension
+
+Install the [shadcn-vue](https://marketplace.visualstudio.com/items?itemName=Selemondev.shadcn-vue) extension in Visual Studio Code to easily add Shadcn Vue components to your project. This extension offers a range of features, including the ability to initialize the Shadcn Vue CLI, install components, open Shadcn Vue docs, and navigate to a specific component's documentation page directly from your IDE. Additionally, it comes with handy snippets for quick and straightforward component imports and markup.


### PR DESCRIPTION
This pull request is intended to add the [shadcn/vue](https://marketplace.visualstudio.com/items?itemName=Selemondev.shadcn-vue) VSCode extension to the installation guide.

Closes: #162