### PR TITLE
Update CommandList.vue

### DIFF
--- a/apps/www/src/lib/registry/new-york/ui/command/CommandList.vue
+++ b/apps/www/src/lib/registry/new-york/ui/command/CommandList.vue
@@ -11,6 +11,8 @@ const forwarded = useForwardPropsEmits(props, emits)
 
 <template>
   <ComboboxContent v-bind="forwarded" :class="cn('max-h-[300px] overflow-y-auto overflow-x-hidden', $attrs.class ?? '')">
-    <slot />
+    <div role="presentation">
+      <slot />
+    </div>
   </ComboboxContent>
 </template>


### PR DESCRIPTION
A `<div role="presentation">` is missing from "new-york" but exists in "default"

Fixing #174 