### PR TITLE
fix: card padding

### DIFF
--- a/apps/www/src/lib/registry/default/ui/card/CardContent.vue
+++ b/apps/www/src/lib/registry/default/ui/card/CardContent.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div :class="cn('p-6 pt-0', props.class)">
+  <div :class="cn('p-6 peer peer-[.p-6]:pt-0', props.class)">
     <slot />
   </div>
 </template>

--- a/apps/www/src/lib/registry/default/ui/card/CardFooter.vue
+++ b/apps/www/src/lib/registry/default/ui/card/CardFooter.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div :class="cn('p-6 pt-0', props.class)">
+  <div :class="cn('p-6 peer-[.p-6]:pt-0', props.class)">
     <slot />
   </div>
 </template>

--- a/apps/www/src/lib/registry/default/ui/card/CardHeader.vue
+++ b/apps/www/src/lib/registry/default/ui/card/CardHeader.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div :class="cn('flex flex-col space-y-1.5 p-6', props.class)">
+  <div :class="cn('flex flex-col space-y-1.5 p-6 peer', props.class)">
     <slot />
   </div>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/card/CardContent.vue
+++ b/apps/www/src/lib/registry/new-york/ui/card/CardContent.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div :class="cn('p-6 pt-0', props.class)">
+  <div :class="cn('p-6 peer peer-[.p-6]:pt-0', props.class)">
     <slot />
   </div>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/card/CardFooter.vue
+++ b/apps/www/src/lib/registry/new-york/ui/card/CardFooter.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div :class="cn('flex items-center p-6 pt-0', props.class)">
+  <div :class="cn('flex items-center p-6 peer-[.p-6]:pt-0', props.class)">
     <slot />
   </div>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/card/CardHeader.vue
+++ b/apps/www/src/lib/registry/new-york/ui/card/CardHeader.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div :class="cn('flex flex-col space-y-1.5 p-6', props.class)">
+  <div :class="cn('flex flex-col space-y-1.5 p-6 peer', props.class)">
     <slot />
   </div>
 </template>


### PR DESCRIPTION
CardHeader and CardFooter should be optional when using Card, and paddings should be correct regardless. 

I've applied peer class to only set pt-0 if a peer with pt-6 is present. 

```html
    <div>
      <Card :class="cn('w-[380px]', $attrs.class ?? '')">
        <CardHeader>
          <CardTitle>Title</CardTitle>
        </CardHeader>
        <CardContent> Content </CardContent>
        <CardFooter>Footer</CardFooter>
      </Card>
    </div>
      <div>
      <Card :class="cn('w-[380px]', $attrs.class ?? '')">
          <CardHeader>
          <CardTitle>Header only</CardTitle>
        </CardHeader>
      </Card>
    </div>
    <div>
      <Card :class="cn('w-[380px]', $attrs.class ?? '')">
        <CardContent> Content only </CardContent>
      </Card>
    </div>
    <div>
      <Card :class="cn('w-[380px]', $attrs.class ?? '')">
        <CardFooter>Footer only</CardFooter>
      </Card>
    </div>
    <div>
      <Card :class="cn('w-[380px]', $attrs.class ?? '')">
        <CardContent> Content </CardContent>
        <CardFooter>Footer</CardFooter>
      </Card>
    </div>
      <div>
      <Card :class="cn('w-[380px]', $attrs.class ?? '')">
        <CardHeader>
          <CardTitle>Title</CardTitle>
        </CardHeader>
        <CardContent> Content </CardContent>
      </Card>
    </div>
```

![image](https://github.com/radix-vue/shadcn-vue/assets/184536/d08af1ad-5367-4495-840c-c7fbdf715355)



