### PR TITLE
docs: add `v-model.lazy` note for custom Vue components

### DIFF
--- a/apps/www/__registry__/index.ts
+++ b/apps/www/__registry__/index.ts
@@ -373,6 +373,13 @@ export const Index = {
       component: () => import('../src/lib/registry/default/example/InputForm.vue').then(m => m.default),
       files: ['../src/lib/registry/default/example/InputForm.vue'],
     },
+    InputLazyForm: {
+      name: 'InputLazyForm',
+      type: 'components:example',
+      registryDependencies: ['button', 'form', 'input', 'toast'],
+      component: () => import('../src/lib/registry/default/example/InputLazyForm.vue').then(m => m.default),
+      files: ['../src/lib/registry/default/example/InputLazyForm.vue'],
+    },
     InputFormAutoAnimate: {
       name: 'InputFormAutoAnimate',
       type: 'components:example',

--- a/apps/www/__registry__/index.ts
+++ b/apps/www/__registry__/index.ts
@@ -401,6 +401,13 @@ export const Index = {
       component: () => import('../src/lib/registry/default/example/InputWithLabel.vue').then(m => m.default),
       files: ['../src/lib/registry/default/example/InputWithLabel.vue'],
     },
+    InputLazyDemo: {
+      name: 'InputLazyDemo',
+      type: 'components:example',
+      registryDependencies: ['input', 'button'],
+      component: () => import('../src/lib/registry/default/example/InputLazyDemo.vue').then(m => m.default),
+      files: ['../src/lib/registry/default/example/InputLazyDemo.vue'],
+    },
     LabelDemo: {
       name: 'LabelDemo',
       type: 'components:example',

--- a/apps/www/src/content/docs/components/form.md
+++ b/apps/www/src/content/docs/components/form.md
@@ -336,3 +336,16 @@ See the following links for more examples on how to use the `vee-validate` featu
 This example shows how to add motion to your forms with [Formkit AutoAnimate](https://auto-animate.formkit.com/)
 
 <ComponentPreview name="InputFormAutoAnimate" />
+
+
+This example show how to use `v-model.lazy`-like in VeeValidate with `validateOnChange`
+
+<Callout class="mt-4">
+
+`v-model` modifiers don't work on custom Vue components
+
+</Callout>
+
+<ComponentPreview name="InputLazyForm" />
+
+

--- a/apps/www/src/content/docs/components/input.md
+++ b/apps/www/src/content/docs/components/input.md
@@ -63,10 +63,18 @@ import { Input } from '@/components/ui/input'
 
 <ComponentPreview name="InputWithButton" class="max-w-xs" />
 
+### Lazy (v-model.lazy)
+
+<Callout class="mt-4">
+
+`v-model` modifiers don't work on custom Vue components,
+
+instead you can use `@change` event on custom Vue component
+
+</Callout>
+
+<ComponentPreview name="InputLazyDemo" class="max-w-xs" />
+
 ### Form
 
 <ComponentPreview name="InputForm" />
-
-#### v-model.lazy binding
-
-<ComponentPreview name="InputLazyForm" />

--- a/apps/www/src/content/docs/components/input.md
+++ b/apps/www/src/content/docs/components/input.md
@@ -66,3 +66,7 @@ import { Input } from '@/components/ui/input'
 ### Form
 
 <ComponentPreview name="InputForm" />
+
+#### v-model.lazy binding
+
+<ComponentPreview name="InputLazyForm" />

--- a/apps/www/src/lib/registry/default/example/InputLazyDemo.vue
+++ b/apps/www/src/lib/registry/default/example/InputLazyDemo.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Input } from '@/lib/registry/default/ui/input'
+
+const emailRef = ref('')
+</script>
+
+<template>
+  <div class="w-full">
+    <Input type="email" placeholder="Email" @change="event => emailRef = event.target.value" />
+
+    <div>
+      {{ emailRef }}
+    </div>
+  </div>
+</template>

--- a/apps/www/src/lib/registry/default/example/InputLazyForm.vue
+++ b/apps/www/src/lib/registry/default/example/InputLazyForm.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { h } from 'vue'
+import { configure, useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import * as z from 'zod'
+
+import { Button } from '@/lib/registry/default/ui/button'
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/lib/registry/default/ui/form'
+import { Input } from '@/lib/registry/default/ui/input'
+import { toast } from '@/lib/registry/default/ui/toast'
+
+configure({
+  validateOnChange: true,
+  validateOnBlur: false,
+  validateOnInput: false,
+  validateOnModelUpdate: false,
+})
+
+const formSchema = toTypedSchema(z.object({
+  username: z.string().min(2).max(50),
+}))
+
+const { handleSubmit } = useForm({
+  validationSchema: formSchema,
+})
+
+const onSubmit = handleSubmit((values) => {
+  toast({
+    title: 'You submitted the following values:',
+    description: h('pre', { class: 'mt-2 w-[340px] rounded-md bg-slate-950 p-4' }, h('code', { class: 'text-white' }, JSON.stringify(values, null, 2))),
+  })
+})
+</script>
+
+<template>
+  <form class="w-2/3 space-y-6" @submit="onSubmit">
+    <FormField v-slot="{ componentField }" name="username">
+      <FormItem>
+        <FormLabel>Username</FormLabel>
+        <FormControl>
+          <Input type="text" placeholder="shadcn" v-bind="componentField" />
+        </FormControl>
+        <FormDescription>
+          This is your public display name.
+        </FormDescription>
+        <FormMessage />
+      </FormItem>
+    </FormField>
+    <Button type="submit">
+      Submit
+    </Button>
+  </Form>
+</template>

--- a/apps/www/src/lib/registry/new-york/example/InputLazyDemo.vue
+++ b/apps/www/src/lib/registry/new-york/example/InputLazyDemo.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Input } from '@/lib/registry/new-york/ui/input'
+
+const emailRef = ref('')
+</script>
+
+<template>
+  <div class="w-full">
+    <Input type="email" placeholder="Email" @change="event => emailRef = event.target.value" />
+
+    <div>
+      {{ emailRef }}
+    </div>
+  </div>
+</template>

--- a/apps/www/src/lib/registry/new-york/example/InputLazyForm.vue
+++ b/apps/www/src/lib/registry/new-york/example/InputLazyForm.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { h } from 'vue'
+import { configure, useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import * as z from 'zod'
+
+import { Button } from '@/lib/registry/new-york/ui/button'
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/lib/registry/new-york/ui/form'
+import { Input } from '@/lib/registry/new-york/ui/input'
+import { toast } from '@/lib/registry/new-york/ui/toast/use-toast'
+
+configure({
+  validateOnChange: true,
+  validateOnBlur: false,
+  validateOnInput: false,
+  validateOnModelUpdate: false,
+})
+
+const formSchema = toTypedSchema(z.object({
+  username: z.string().min(2).max(50),
+}))
+
+const { handleSubmit } = useForm({
+  validationSchema: formSchema,
+})
+
+const onSubmit = handleSubmit((values) => {
+  toast({
+    title: 'You submitted the following values:',
+    description: h('pre', { class: 'mt-2 w-[340px] rounded-md bg-slate-950 p-4' }, h('code', { class: 'text-white' }, JSON.stringify(values, null, 2))),
+  })
+})
+</script>
+
+<template>
+  <form class="w-2/3 space-y-6" @submit="onSubmit">
+    <FormField v-slot="{ componentField }" name="username">
+      <FormItem>
+        <FormLabel>Username</FormLabel>
+        <FormControl>
+          <Input type="text" placeholder="shadcn" v-bind="componentField" />
+        </FormControl>
+        <FormDescription>
+          This is your public display name.
+        </FormDescription>
+        <FormMessage />
+      </FormItem>
+    </FormField>
+    <Button type="submit">
+      Submit
+    </Button>
+  </Form>
+</template>


### PR DESCRIPTION
> `v-model` in components is just sugar syntax, it doesn't support modifiers

If you look at these links `v-model modifiers` will not work on custom Vue components like `Input`

- [Vuetify Input Playground](https://play.vuetifyjs.com/#eNpNj8EKgzAMhl8l5OIGU2EeBsMJe4Pd5w5OoxRaLW2UbeK7L9qLpyQk//eR54ze1end2mQaCa+YMxmrK6ai7AHyRk1bI+0UM304bhXpBnT1Jn0r8aGp8gSqtyOXCFNshoZ0oqvfV7bGdyUWebqPCi4A51nWy7Jp0uDJ051dRl87ZRk88WhF2XfCZC/INaSMHRzDDI5aWKB1g4FInoiCoB56zyAKuK0Xhyg6roKAFAAuJ8ySLLlgqOcMX3+dollJ)

- [ElementPlus Input Playground](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGVsLWlucHV0IHYtbW9kZWwubGF6eT1cImlucHV0XCIgcGxhY2Vob2xkZXI9XCJQbGVhc2UgaW5wdXRcIiAvPlxuXG4gIHt7aW5wdXR9fVxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmNvbnN0IGlucHV0ID0gcmVmKCcnKVxuPC9zY3JpcHQ+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7fVxufSIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJfbyI6e319)


I thought it would be better to mention this in the docs of how to work with lazy inputs without `v-model.lazy` modifier in `Input` component and `VeeValidate` forms
