### PR TITLE
fix: theme switcher current colors

### DIFF
--- a/apps/www/.vitepress/theme/layout/ThemingLayout.vue
+++ b/apps/www/.vitepress/theme/layout/ThemingLayout.vue
@@ -98,7 +98,7 @@ watch(radius, (radius) => {
                       class="flex h-9 w-9 items-center justify-center rounded-full border-2 border-border text-xs"
                       :class="
                         color === theme
-                          ? 'border-foreground'
+                          ? 'border-primary'
                           : 'border-transparent'
                       "
                       @click="setTheme(color)"

--- a/apps/www/.vitepress/theme/layout/ThemingLayout.vue
+++ b/apps/www/.vitepress/theme/layout/ThemingLayout.vue
@@ -117,7 +117,7 @@ watch(radius, (radius) => {
                   <TooltipContent
                     align="center"
                     :side-offset="1"
-                    class="capitalize"
+                    class="capitalize bg-zinc-900"
                   >
                     {{ allColors[index] }}
                   </TooltipContent>

--- a/apps/www/.vitepress/theme/layout/ThemingLayout.vue
+++ b/apps/www/.vitepress/theme/layout/ThemingLayout.vue
@@ -105,7 +105,7 @@ watch(radius, (radius) => {
                     >
                       <span
                         class="flex h-6 w-6 items-center justify-center rounded-full"
-                        :style="{ backgroundColor: colors[color][7].rgb }"
+                        :style="{ backgroundColor: colors[color][6].rgb }"
                       >
                         <RadixIconsCheck
                           v-if="color === theme"


### PR DESCRIPTION
On the theme switcher, there are a few inconsistencies in the current color indicator:

- The border color of the current color indicator doesn't match the selected color. This is the behavior of the main [shadcn theme switcher](https://ui.shadcn.com/themes)
- The background color is also slightly off.
- The tooltip background color is that of the current color rather than a dark background

This PR fixes all of these.

Before:
<img width="649" alt="Screenshot 2023-12-01 at 4 03 38 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/eee738da-ec7a-42d4-ab65-b6677f92f477">
<img width="644" alt="Screenshot 2023-12-01 at 4 02 53 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/ece8e595-4f32-4a0a-8300-afb5e6d0884a">
<img width="658" alt="Screenshot 2023-12-01 at 4 35 29 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/c1157514-ffc9-4d25-858c-add0721ea4b4">
<img width="647" alt="Screenshot 2023-12-01 at 4 34 44 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/8c349790-2542-4950-bec2-ce51a7be28d6">


After
<img width="654" alt="Screenshot 2023-12-01 at 4 21 07 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/0a28f65f-bb10-4c64-b2aa-9612422055ee">
<img width="653" alt="Screenshot 2023-12-01 at 4 21 15 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/079892a8-84a4-4f4e-94ac-add7c81fd21e">
<img width="645" alt="Screenshot 2023-12-01 at 4 21 01 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/3790a62b-019e-40db-b019-9e28d5cff8f5">
<img width="662" alt="Screenshot 2023-12-01 at 4 20 51 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/10b3f44e-a429-4275-9c59-d13cba6c6908">
<img width="644" alt="Screenshot 2023-12-01 at 4 33 01 PM" src="https://github.com/radix-vue/shadcn-vue/assets/2565382/a57ed026-6e67-4277-a3a2-7b837686ac2f">
