### PR TITLE
fix: fixed create project command typo

### DIFF
--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -7,7 +7,7 @@ description: Install and configure Nuxt.
 
 ### Create project
 
-Start by creating a new Nuxt project using `create-next-app`:
+Start by creating a new Nuxt project using `create-nuxt-app`:
 
 ```bash
 npx nuxi@latest init my-app


### PR DESCRIPTION
`create-next-app` -> `create-nuxt-app`