### PR TITLE
fix: allow .ts or .js extension in module package

### DIFF
--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -1,4 +1,5 @@
 import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
 import { addComponent, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { Project } from 'ts-morph'
 
@@ -29,7 +30,7 @@ export default defineNuxtModule<ModuleOptions>({
     const COMPONENT_DIR_PATH = options.componentDir!
     const ROOT_DIR_PATH = nuxt.options.rootDir
 
-    const { resolve } = createResolver(ROOT_DIR_PATH)
+    const { resolve, resolvePath } = createResolver(ROOT_DIR_PATH)
 
     nuxt.options.ignore.push(IGNORE_DIR)
     nuxt._ignore?.add(IGNORE_DIR)
@@ -38,7 +39,7 @@ export default defineNuxtModule<ModuleOptions>({
     try {
       readdirSync(resolve(COMPONENT_DIR_PATH))
         .forEach(async (dir) => {
-          const filePath = resolve(COMPONENT_DIR_PATH, dir, 'index.ts')
+          const filePath = await resolvePath(join(COMPONENT_DIR_PATH, dir, 'index'), { extensions: ['.ts', '.js'] })
 
           const project = new Project()
           project.addSourceFileAtPath(filePath)

--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -1,5 +1,5 @@
 import { readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { join } from 'pathe'
 import { addComponent, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { Project } from 'ts-morph'
 


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the `module` `package`, there is an issue related to the hardcoded reference to the `index.ts` file for each component.

The problem arises when opting not to use TypeScript while configuring the `components.json`. In such cases, upon adding a new `shadcn` component, the CLI generates an `index.js` file instead of a `index.ts` file.

Consequently, during project startup, an error occurs with the message `ERROR [unhandledRejection] File not found: C:/[...]/components/ui/avatar/index.ts` for each component (for clarity, the folder structure and the component name are on a per-installed component basis, and is not always `avatar`).

This pull request addresses this bug by introducing a fix that checks for either file (`index.ts` or `index.js`), preventing the aforementioned error during project initialization.

### 📸 Screenshots (if appropriate)

#### Before

![Console On Startup - Before](https://github.com/radix-vue/shadcn-vue/assets/12871513/d396d6c4-411a-42bf-9778-8563bbceaf00)

#### After

![Console On Startup - After](https://github.com/radix-vue/shadcn-vue/assets/12871513/f71670e5-f1fb-418f-aba3-7828f16b7d9e)