### PR TITLE
docs: replace nbsp with a space when copying

### DIFF
--- a/apps/www/.vitepress/theme/components/CustomizerCode.vue
+++ b/apps/www/.vitepress/theme/components/CustomizerCode.vue
@@ -15,7 +15,7 @@ const { copy, copied } = useClipboard()
 
 const codeRef = ref<HTMLElement>()
 async function copyCode() {
-  await copy(codeRef.value?.innerText ?? '')
+  await copy(codeRef.value?.innerText.replace(/\u00A0/g, " ") ?? '')
 }
 </script>
 


### PR DESCRIPTION
currently when using the copy button in [themes page](https://www.shadcn-vue.com/themes.html), the code is copied along with non-breaking-space, which breaks the code and styles are not applied (vscode shows these characters with yellow highlighting)
this PR fixes this by replacing the nbsp with a normal space
**Before**
![screenshot with broken code](https://github.com/radix-vue/shadcn-vue/assets/26815728/ef591077-1641-4bdb-b38f-2d067dad3e75)
**After**
![screenshot with working code](https://github.com/radix-vue/shadcn-vue/assets/26815728/492c92fb-ebc2-469c-ace8-60dea6442b16)
