### PR TITLE
docs: change cards radius to `rounded-lg`

### DIFF
--- a/apps/www/.vitepress/theme/components/LinkedCard.vue
+++ b/apps/www/.vitepress/theme/components/LinkedCard.vue
@@ -3,7 +3,7 @@ import { cn } from '@/lib/utils'
 </script>
 
 <template>
-  <a :class="cn('flex w-full flex-col items-center rounded-xl border bg-card p-6 text-card-foreground shadow transition-colors hover:bg-muted/50 sm:p-10', $attrs.class ?? '')">
+  <a :class="cn('flex w-full flex-col items-center rounded-lg border bg-card p-6 text-card-foreground shadow transition-colors hover:bg-muted/50 sm:p-10', $attrs.class ?? '')">
     <slot />
   </a>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/card/Card.vue
+++ b/apps/www/src/lib/registry/new-york/ui/card/Card.vue
@@ -13,7 +13,7 @@ const props = defineProps({
   <div
     :class="
       cn(
-        'rounded-xl border bg-card text-card-foreground shadow',
+        'rounded-lg border bg-card text-card-foreground shadow',
         props.class,
       )
     "

--- a/apps/www/src/public/registry/styles/new-york/card.json
+++ b/apps/www/src/public/registry/styles/new-york/card.json
@@ -7,7 +7,7 @@
   "files": [
     {
       "name": "Card.vue",
-      "content": "<script setup lang=\"ts\">\nimport { cn } from '@/lib/utils'\n\nconst props = defineProps({\n  class: {\n    type: String,\n    default: '',\n  },\n})\n</script>\n\n<template>\n  <div\n    :class=\"\n      cn(\n        'rounded-xl border bg-card text-card-foreground shadow',\n        props.class,\n      )\n    \"\n  >\n    <slot />\n  </div>\n</template>\n"
+      "content": "<script setup lang=\"ts\">\nimport { cn } from '@/lib/utils'\n\nconst props = defineProps({\n  class: {\n    type: String,\n    default: '',\n  },\n})\n</script>\n\n<template>\n  <div\n    :class=\"\n      cn(\n        'rounded-lg border bg-card text-card-foreground shadow',\n        props.class,\n      )\n    \"\n  >\n    <slot />\n  </div>\n</template>\n"
     },
     {
       "name": "CardContent.vue",


### PR DESCRIPTION
currently, when changing the radius in [themes page](https://www.shadcn-vue.com/themes.html), the radius only changes on the first two cards because the `Card.vue` component has a rounded-xl class, which is wrong cuz it doesn't use `--radius` in the css
Before
![cards with rounded-xl](https://github.com/radix-vue/shadcn-vue/assets/26815728/4c7857a6-671b-4973-917e-648c010d869d)
After
![cards with rounded-lg](https://github.com/radix-vue/shadcn-vue/assets/26815728/e0c2ab03-a6a1-4fca-bd4d-140ead9186b7)

p.s. `LinkedCard.vue` has also changed to use rounded-lg, so now if the user changes the radius, it will be applied to that element as well:
![LinkedCard.vue](https://github.com/radix-vue/shadcn-vue/assets/26815728/2d9ebf13-7418-4452-87bc-31df41540c87)
