### PR TITLE
fix: typo in nuxt-module

### DIFF
--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -40,7 +40,7 @@ export default defineNuxtModule<ModuleOptions>({
     try {
       readdirSync(resolve(COMPONENT_DIR_PATH))
         .forEach(async (dir) => {
-          const filePath = await resolvePath(join(COMPONENT_DIR_PATH, dir, 'index'), { extensions: ['.ts', 'js'] })
+          const filePath = await resolvePath(join(COMPONENT_DIR_PATH, dir, 'index'), { extensions: ['.ts', '.js'] })
           const content = readFileSync(filePath, { encoding: 'utf8' })
           const ast = parse(content)
 


### PR DESCRIPTION
This is a quick typo fix for `nuxt-module`. It cannot find `index.js` file for shadcn components otherwise.