### PR TITLE
fix remove today design when in the current range

### DIFF
--- a/apps/www/src/lib/registry/default/ui/calendar/Calendar.vue
+++ b/apps/www/src/lib/registry/default/ui/calendar/Calendar.vue
@@ -118,7 +118,7 @@ onMounted(async () => {
 .calendar .vc-day:has(.vc-highlights) {
   @apply bg-accent first:rounded-l-md last:rounded-r-md overflow-hidden;
 }
-.calendar .vc-day.is-today {
+.calendar .vc-day.is-today:not(:has(.vc-day-layer)) {
   @apply bg-secondary rounded-md;
 }
 .calendar .vc-day:has(.vc-highlight-base-start) {


### PR DESCRIPTION
Hey @sadeghbarati

Don't you think we should add a `:not(:has(.vc-day-layer))` to the selector you've added in #251 ?
```css
.calendar .vc-day.is-today:not(:has(.vc-day-layer)) {
  @apply bg-secondary rounded-md;
}
```

This avoids the problem of rounded edges when today is in the current range or the start/end of range:
![CleanShot 2024-01-08 at 10 21 21](https://github.com/radix-vue/shadcn-vue/assets/20521112/d58f300a-bf75-417c-93ac-6e5ed9d42e0f)
![CleanShot 2024-01-08 at 10 21 44](https://github.com/radix-vue/shadcn-vue/assets/20521112/cedd22e5-0307-4aec-b382-472427c34bb1)
![CleanShot 2024-01-08 at 10 22 11](https://github.com/radix-vue/shadcn-vue/assets/20521112/a7d7c02c-6cf9-4500-92ae-3eacd646964a)


With the fix:
![CleanShot 2024-01-08 at 10 22 56](https://github.com/radix-vue/shadcn-vue/assets/20521112/32ca3a59-72d0-477d-b45f-63544ff16a85)
![CleanShot 2024-01-08 at 10 23 29](https://github.com/radix-vue/shadcn-vue/assets/20521112/bada4957-a042-42aa-b360-11866f2ee2ed)


