### PR TITLE
Safelist `dark` when CSS variable colors are used.

### DIFF
--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -51,6 +51,7 @@ export const TAILWIND_CONFIG_WITH_VARIABLES = `const animate = require("tailwind
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: ["class"],
+  safelist: ["dark"],
   <% if (framework === 'vite') { %>
   content: [
     './pages/**/*.{<%- extension %>,<%- extension %>x,vue}',


### PR DESCRIPTION
This PR adds `dark` to the safelist for the CSS variables version of `tailwind.config.(js|ts)`, should fix https://github.com/radix-vue/shadcn-vue/issues/78. 