### PR TITLE
feat(cli): Add JSON schema

### DIFF
--- a/apps/www/src/public/schema.json
+++ b/apps/www/src/public/schema.json
@@ -6,6 +6,10 @@
       "type": "string",
       "enum": ["default", "new-york"]
     },
+    "typescript": {
+      "type": "boolean",
+      "default": true
+    },
     "tailwind": {
       "type": "object",
       "properties": {
@@ -19,11 +23,17 @@
           "type": "string"
         },
         "cssVariables": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         }
       },
       "required": ["config", "css", "baseColor", "cssVariables"]
-    },  
+    },
+    "framework": {
+      "type": "string",
+      "enum": ["nuxt", "vite", "laravel", "astro"],
+      "default": "vite"
+    },
     "aliases": {
       "type": "object",
       "properties": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -178,7 +178,7 @@ export async function promptForConfig(
   ])
 
   const config = rawConfigSchema.parse({
-    // $schema: 'https://ui.shadcn.com/schema.json',
+    $schema: 'https://shadcn-vue.com/schema.json',
     style: options.style,
     typescript: options.typescript,
     framework: options.framework,


### PR DESCRIPTION
Add (back?) the `$schema` property to the newly created `components.json`.

It will help users have a "type-safe" configuration, as all other shadcn/ui implementations do.