### PR TITLE
fix(about.md): corrected a url typo

### DIFF
--- a/apps/www/src/content/docs/about.md
+++ b/apps/www/src/content/docs/about.md
@@ -5,7 +5,7 @@ description: Powered by amazing open source projects.
 
 ## About
 
-[shadcn-vue](https://shadcn-vuee.com) is a port of [shadcn/ui](https://ui.shadcn.com) for Vue/Nuxt. It's maintained by [radix-vue](https://github.com/radix-vue).
+[shadcn-vue](https://shadcn-vue.com) is a port of [shadcn/ui](https://ui.shadcn.com) for Vue/Nuxt. It's maintained by [radix-vue](https://github.com/radix-vue).
 
 ## Credits
 


### PR DESCRIPTION
Corrected a url typo from https://shadcn-vuee.com to https://shadcn-vue.com