### PR TITLE
fix: hide navigation in "time" mode

### DIFF
--- a/apps/www/src/lib/registry/default/ui/calendar/Calendar.vue
+++ b/apps/www/src/lib/registry/default/ui/calendar/Calendar.vue
@@ -68,7 +68,7 @@ onMounted(async () => {
 
 <template>
   <div class="relative">
-    <div class="absolute flex justify-between w-full px-4 top-3 z-[1]">
+    <div v-if="$attrs.mode !== 'time'" class="absolute flex justify-between w-full px-4 top-3 z-[1]">
       <button :class="cn(buttonVariants({ variant: 'outline' }), 'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100')" @click="handleNav('prev')">
         <ChevronLeft class="w-4 h-4" />
       </button>

--- a/apps/www/src/lib/registry/new-york/ui/calendar/Calendar.vue
+++ b/apps/www/src/lib/registry/new-york/ui/calendar/Calendar.vue
@@ -67,7 +67,7 @@ onMounted(async () => {
 
 <template>
   <div class="relative">
-    <div class="absolute flex justify-between w-full px-4 top-3 z-[1]">
+    <div v-if="$attrs.mode !== 'time'" class="absolute flex justify-between w-full px-4 top-3 z-[1]">
       <button :class="cn(buttonVariants({ variant: 'outline' }), 'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100')" @click="handleNav('prev')">
         <ChevronLeftIcon class="w-4 h-4" />
       </button>


### PR DESCRIPTION
This PR will hide navigation buttons in time mode (not date).

For more complex needs, it may be useful to use the `Calendar` component in `time` only mode. In particular, to be able to customize the appearance more easily, example :


```js
<Calendar 
  type="range"
  v-model.range="form.date.range" 
  mode="date" 
  :columns="2"
>
<template #footer>
  <div class="w-full">
    Entry time:
    <Calendar 
      v-model="form.date.range.start" 
      mode="time" 
      hide-time-header
      is24hr
    />
    Exit time:
    <Calendar 
      v-model="form.date.range.end" 
      mode="time" 
      hide-time-header
      is24hr
    />
  </div>
</template>
</Calendar>
```

The problem is that without this fix, the navigation chevrons appear:

![CleanShot 2024-01-17 at 19 38 35](https://github.com/radix-vue/shadcn-vue/assets/20521112/eac34488-788f-4b0f-aab7-c08bcf4fbfca)