### PR TITLE
Update vite.md to resolve path without error

### DIFF
--- a/apps/www/src/content/docs/installation/vite.md
+++ b/apps/www/src/content/docs/installation/vite.md
@@ -42,6 +42,11 @@ Add the code below to the compilerOptions of your tsconfig.json so your app can 
 
 Add the code below to the vite.config.ts so your app can resolve paths without error
 
+```bash
+# (so you can import "path" without error)
+npm i -D @types/node
+```
+
 ```typescript
 import path from "path"
 import vue from "@vitejs/plugin-vue"


### PR DESCRIPTION
Add install `@types/node` to follow the documentation in shadcn-ui. And import path without an error, as `path` is recognized without installing `@types/node`