### PR TITLE
fix: separator background color

### DIFF
--- a/apps/www/src/lib/registry/default/ui/separator/Separator.vue
+++ b/apps/www/src/lib/registry/default/ui/separator/Separator.vue
@@ -8,7 +8,7 @@ const props = defineProps<SeparatorProps & { class?: string }>()
 <template>
   <Separator
     :class="[
-      cn('shrink-0 bg-secondary', props.class),
+      cn('shrink-0 bg-border', props.class),
       props.orientation === 'vertical' ? 'w-px h-full' : 'h-px w-full',
     ]"
   />

--- a/apps/www/src/lib/registry/new-york/ui/separator/Separator.vue
+++ b/apps/www/src/lib/registry/new-york/ui/separator/Separator.vue
@@ -8,7 +8,7 @@ const props = defineProps<SeparatorProps & { class?: string }>()
 <template>
   <Separator
     :class="[
-      cn('shrink-0 bg-secondary', props.class),
+      cn('shrink-0 bg-border', props.class),
       props.orientation === 'vertical' ? 'w-px h-full' : 'h-px w-full',
     ]"
   />


### PR DESCRIPTION
I noticed some contrast issues with the separator component, which I didn't have with the original version. I checked the sources and saw they use a different class for the separator background.

Default: https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/default/ui/separator.tsx
New York: https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/new-york/ui/separator.tsx

Updating the color fixed all my contrast issues.