### PR TITLE
fix: `useForwardProps` for vue-sonner props

### DIFF
--- a/apps/www/.vitepress/theme/config/docs.ts
+++ b/apps/www/.vitepress/theme/config/docs.ts
@@ -328,7 +328,6 @@ export const docsConfig: DocsConfig = {
         {
           title: 'Toast',
           href: '/docs/components/toast',
-          label: 'New',
           items: [],
         },
         {

--- a/apps/www/.vitepress/theme/layout/DocsLayout.vue
+++ b/apps/www/.vitepress/theme/layout/DocsLayout.vue
@@ -46,7 +46,7 @@ const sourceLink = 'https://github.com/radix-vue/shadcn-vue/tree/dev/'
                 >
                   {{ doc.title }}
 
-                  <Badge v-if="doc.label" class="ml-2" :variant="'secondary'">
+                  <Badge v-if="doc.label" class="ml-2 rounded-md !bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline" variant="default">
                     {{ doc.label }}
                   </Badge>
                 </a>

--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -288,7 +288,9 @@ watch(() => $route.path, (n) => {
       </DialogContent>
     </Dialog>
     <DefaultToaster />
-    <NewYorkSonner :theme="isDark ? 'dark' : 'light'" />
+    <ClientOnly>
+      <NewYorkSonner :theme="isDark ? 'dark' : 'light'" />
+    </ClientOnly>
     <NewYorkToaster />
   </div>
 </template>

--- a/apps/www/src/lib/registry/default/ui/sonner/Sonner.vue
+++ b/apps/www/src/lib/registry/default/ui/sonner/Sonner.vue
@@ -1,7 +1,10 @@
 <script lang="ts" setup>
+import { useForwardProps } from 'radix-vue'
 import { Toaster as Sonner, type ToasterProps } from 'vue-sonner'
 
 const props = defineProps<ToasterProps>()
+
+const forwardedProps = useForwardProps(props)
 </script>
 
 <template>
@@ -16,6 +19,6 @@ const props = defineProps<ToasterProps>()
       cancelButton:
         'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
     }"
-    v-bind="props"
+    v-bind="forwardedProps"
   />
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/sonner/Sonner.vue
+++ b/apps/www/src/lib/registry/new-york/ui/sonner/Sonner.vue
@@ -1,7 +1,10 @@
 <script lang="ts" setup>
+import { useForwardProps } from 'radix-vue'
 import { Toaster as Sonner, type ToasterProps } from 'vue-sonner'
 
 const props = defineProps<ToasterProps>()
+
+const forwardedProps = useForwardProps(props)
 </script>
 
 <template>
@@ -16,6 +19,6 @@ const props = defineProps<ToasterProps>()
       cancelButton:
         'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
     }"
-    v-bind="props"
+    v-bind="forwardedProps"
   />
 </template>

--- a/apps/www/src/public/registry/styles/default/sonner.json
+++ b/apps/www/src/public/registry/styles/default/sonner.json
@@ -7,7 +7,7 @@
   "files": [
     {
       "name": "Sonner.vue",
-      "content": "<script lang=\"ts\" setup>\nimport { Toaster as Sonner, type ToasterProps } from 'vue-sonner'\n\nconst props = defineProps<ToasterProps>()\n</script>\n\n<template>\n  <Sonner\n    class=\"toaster group\"\n    :class-names=\"{\n      toast:\n        'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',\n      description: 'group-[.toast]:text-muted-foreground',\n      actionButton:\n        'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',\n      cancelButton:\n        'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',\n    }\"\n    v-bind=\"props\"\n  />\n</template>\n"
+      "content": "<script lang=\"ts\" setup>\nimport { useForwardProps } from 'radix-vue'\nimport { Toaster as Sonner, type ToasterProps } from 'vue-sonner'\n\nconst props = defineProps<ToasterProps>()\n\nconst forwardedProps = useForwardProps(props)\n</script>\n\n<template>\n  <Sonner\n    class=\"toaster group\"\n    :class-names=\"{\n      toast:\n        'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',\n      description: 'group-[.toast]:text-muted-foreground',\n      actionButton:\n        'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',\n      cancelButton:\n        'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',\n    }\"\n    v-bind=\"forwardedProps\"\n  />\n</template>\n"
     },
     {
       "name": "index.ts",

--- a/apps/www/src/public/registry/styles/new-york/sonner.json
+++ b/apps/www/src/public/registry/styles/new-york/sonner.json
@@ -7,7 +7,7 @@
   "files": [
     {
       "name": "Sonner.vue",
-      "content": "<script lang=\"ts\" setup>\nimport { Toaster as Sonner, type ToasterProps } from 'vue-sonner'\n\nconst props = defineProps<ToasterProps>()\n</script>\n\n<template>\n  <Sonner\n    class=\"toaster group\"\n    :class-names=\"{\n      toast:\n        'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',\n      description: 'group-[.toast]:text-muted-foreground',\n      actionButton:\n        'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',\n      cancelButton:\n        'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',\n    }\"\n    v-bind=\"props\"\n  />\n</template>\n"
+      "content": "<script lang=\"ts\" setup>\nimport { useForwardProps } from 'radix-vue'\nimport { Toaster as Sonner, type ToasterProps } from 'vue-sonner'\n\nconst props = defineProps<ToasterProps>()\n\nconst forwardedProps = useForwardProps(props)\n</script>\n\n<template>\n  <Sonner\n    class=\"toaster group\"\n    :class-names=\"{\n      toast:\n        'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',\n      description: 'group-[.toast]:text-muted-foreground',\n      actionButton:\n        'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',\n      cancelButton:\n        'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',\n    }\"\n    v-bind=\"forwardedProps\"\n  />\n</template>\n"
     },
     {
       "name": "index.ts",


### PR DESCRIPTION
`useForwardProps` is used in Component Wrapper of `vue-sonner` to prevent casting **undefined boolean** props as **false**