### PR TITLE
[Bug Fix] ScrollBar width

### DIFF
--- a/apps/www/src/lib/registry/default/ui/scroll-area/ScrollBar.vue
+++ b/apps/www/src/lib/registry/default/ui/scroll-area/ScrollBar.vue
@@ -18,6 +18,6 @@ const props = withDefaults(defineProps<ScrollAreaScrollbarProps>(), {
            && 'h-2.5 border-t border-t-transparent p-[1px]',
          $attrs.class ?? '')"
   >
-    <ScrollAreaThumb class="relative rounded-full bg-border" />
+    <ScrollAreaThumb class="relative flex-1 rounded-full bg-border" />
   </ScrollAreaScrollbar>
 </template>

--- a/apps/www/src/lib/registry/default/ui/scroll-area/ScrollBar.vue
+++ b/apps/www/src/lib/registry/default/ui/scroll-area/ScrollBar.vue
@@ -18,6 +18,6 @@ const props = withDefaults(defineProps<ScrollAreaScrollbarProps>(), {
            && 'h-2.5 border-t border-t-transparent p-[1px]',
          $attrs.class ?? '')"
   >
-    <ScrollAreaThumb class="relative flex-1 rounded-full bg-border" />
+    <ScrollAreaThumb class="relative rounded-full bg-border" />
   </ScrollAreaScrollbar>
 </template>

--- a/apps/www/src/lib/registry/default/ui/scroll-area/ScrollBar.vue
+++ b/apps/www/src/lib/registry/default/ui/scroll-area/ScrollBar.vue
@@ -15,7 +15,7 @@ const props = withDefaults(defineProps<ScrollAreaScrollbarProps>(), {
          orientation === 'vertical'
            && 'h-full w-2.5 border-l border-l-transparent p-[1px]',
          orientation === 'horizontal'
-           && 'h-2.5 border-t border-t-transparent p-[1px]',
+           && 'h-2.5 flex-col border-t border-t-transparent p-[1px]',
          $attrs.class ?? '')"
   >
     <ScrollAreaThumb class="relative flex-1 rounded-full bg-border" />

--- a/apps/www/src/lib/registry/new-york/ui/scroll-area/ScrollBar.vue
+++ b/apps/www/src/lib/registry/new-york/ui/scroll-area/ScrollBar.vue
@@ -18,6 +18,6 @@ const props = withDefaults(defineProps<ScrollAreaScrollbarProps>(), {
            && 'h-2.5 border-t border-t-transparent p-[1px]',
          $attrs.class ?? '')"
   >
-    <ScrollAreaThumb class="relative rounded-full bg-border" />
+    <ScrollAreaThumb class="relative flex-1 rounded-full bg-border" />
   </ScrollAreaScrollbar>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/scroll-area/ScrollBar.vue
+++ b/apps/www/src/lib/registry/new-york/ui/scroll-area/ScrollBar.vue
@@ -18,6 +18,6 @@ const props = withDefaults(defineProps<ScrollAreaScrollbarProps>(), {
            && 'h-2.5 border-t border-t-transparent p-[1px]',
          $attrs.class ?? '')"
   >
-    <ScrollAreaThumb class="relative flex-1 rounded-full bg-border" />
+    <ScrollAreaThumb class="relative rounded-full bg-border" />
   </ScrollAreaScrollbar>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/scroll-area/ScrollBar.vue
+++ b/apps/www/src/lib/registry/new-york/ui/scroll-area/ScrollBar.vue
@@ -15,7 +15,7 @@ const props = withDefaults(defineProps<ScrollAreaScrollbarProps>(), {
          orientation === 'vertical'
            && 'h-full w-2.5 border-l border-l-transparent p-[1px]',
          orientation === 'horizontal'
-           && 'h-2.5 border-t border-t-transparent p-[1px]',
+           && 'h-2.5 flex-col border-t border-t-transparent p-[1px]',
          $attrs.class ?? '')"
   >
     <ScrollAreaThumb class="relative flex-1 rounded-full bg-border" />


### PR DESCRIPTION
Hi,
I think I found a bug in the ScrollBar component.
In the image below, notice that the `flex-1` class assigned to the `ScrollAreaThumb` causes the scrollbar to expand and fill the entire width of the scroll area.
![immagine](https://github.com/radix-vue/shadcn-vue/assets/34713013/a4d785a9-e383-48aa-b2fd-d597b7e95bcb)

Removing the specified class produces the expected behaviour:
![immagine](https://github.com/radix-vue/shadcn-vue/assets/34713013/5df9ab38-7088-413e-bca1-eac6bb209166)
