### PR TITLE
fix: minor fix to display the correct icon on dark mode

### DIFF
--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -144,10 +144,13 @@ watch(() => $route.path, (n) => {
               :variant="'ghost'"
               :size="'icon'" @click="toggleDark()"
             >
+              <!-- workaround for bug with component when refreshing the page -->
               <component
-                :is="isDark ? RadixIconsSun : RadixIconsMoon"
+                :is="RadixIconsMoon"
+                v-if="!isDark"
                 class="w-[20px] h-5 text-foreground"
               />
+              <RadixIconsSun v-if="isDark" class="w-[20px] h-5 text-foreground" />
             </Button>
           </div>
         </div>

--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -138,20 +138,19 @@ watch(() => $route.path, (n) => {
               <component :is="link.icon" class="w-[20px] h-5" />
             </Button>
 
-            <Button
-              class="flex items-center justify-center"
-              aria-label="Toggle dark mode"
-              :variant="'ghost'"
-              :size="'icon'" @click="toggleDark()"
-            >
-              <!-- workaround for bug with component when refreshing the page -->
-              <component
-                :is="RadixIconsMoon"
-                v-if="!isDark"
-                class="w-[20px] h-5 text-foreground"
-              />
-              <RadixIconsSun v-if="isDark" class="w-[20px] h-5 text-foreground" />
-            </Button>
+            <ClientOnly>
+              <Button
+                class="flex items-center justify-center"
+                aria-label="Toggle dark mode"
+                :variant="'ghost'"
+                :size="'icon'" @click="toggleDark()"
+              >
+                <component
+                  :is="isDark ? RadixIconsSun : RadixIconsMoon"
+                  class="w-[20px] h-5 text-foreground"
+                />
+              </Button>
+            </ClientOnly>
           </div>
         </div>
       </div>


### PR DESCRIPTION
I've tried to fix it without recurring into a workaround but when vitepress is built the bug remained, this way, at least, when the vitepress is built the correct icon remained.

_Displaying the bug:_
When changing the theme into dark mode and refreshing the page it displays the wrong icon.

https://github.com/radix-vue/shadcn-vue/assets/2693803/d83fe8c4-316d-4feb-852d-f15a9d3c418f

_The fix:_
With the workaround it "flashes" the wrong icon but the correct one remains.

https://github.com/radix-vue/shadcn-vue/assets/2693803/0dd0507a-ada4-4197-9b9f-e80ba291fbcf


If anyone find the reason for the glitch or have a better way to fix it let me know.

I wish my first help would be a better one but this icon glitch was bugging me 😆
