### PR TITLE
fix(docs): fix `DataTableColumnHeader` usage

### DIFF
--- a/apps/www/src/content/docs/components/data-table.md
+++ b/apps/www/src/content/docs/components/data-table.md
@@ -971,11 +971,9 @@ export const columns = [
   {
     accessorKey: "email",
     header: ({ column }) => (
-        return h(DataTableColumnHeader, {
-            props: {
-                column: column,
-                title: 'Email'
-            }
+        h(DataTableColumnHeader, {
+            column: column,
+            title: 'Email'
         })
     ),
   },


### PR DESCRIPTION
Just a minor fix-up for a thing I stumbled upon while using the `DataTableColumnHeader`