### PR TITLE
Fix: form capitalization

### DIFF
--- a/apps/www/src/lib/registry/default/example/InputForm.vue
+++ b/apps/www/src/lib/registry/default/example/InputForm.vue
@@ -49,5 +49,5 @@ const onSubmit = handleSubmit((values) => {
     <Button type="submit">
       Submit
     </Button>
-  </Form>
+  </form>
 </template>

--- a/apps/www/src/lib/registry/default/example/InputFormAutoAnimate.vue
+++ b/apps/www/src/lib/registry/default/example/InputFormAutoAnimate.vue
@@ -50,5 +50,5 @@ const onSubmit = handleSubmit((values) => {
     <Button type="submit">
       Submit
     </Button>
-  </Form>
+  </form>
 </template>

--- a/apps/www/src/lib/registry/new-york/example/InputForm.vue
+++ b/apps/www/src/lib/registry/new-york/example/InputForm.vue
@@ -49,5 +49,5 @@ const onSubmit = handleSubmit((values) => {
     <Button type="submit">
       Submit
     </Button>
-  </Form>
+  </form>
 </template>

--- a/apps/www/src/lib/registry/new-york/example/InputFormAutoAnimate.vue
+++ b/apps/www/src/lib/registry/new-york/example/InputFormAutoAnimate.vue
@@ -50,5 +50,5 @@ const onSubmit = handleSubmit((values) => {
     <Button type="submit">
       Submit
     </Button>
-  </Form>
+  </form>
 </template>


### PR DESCRIPTION
`Form` should be cased as `form` to match the starting and closing tags and be consistent with docs.