### PR TITLE
Fix bug in code example combobox.md

### DIFF
--- a/apps/www/src/content/docs/components/combobox.md
+++ b/apps/www/src/content/docs/components/combobox.md
@@ -82,7 +82,7 @@ const value = ref('')
               <Check
                 :class="cn(
                   'mr-2 h-4 w-4',
-                  value?.value === framework.value ? 'opacity-100' : 'opacity-0',
+                  value === framework.value ? 'opacity-100' : 'opacity-0',
                 )"
               />
               {{ framework.label }}

--- a/apps/www/src/content/docs/components/combobox.md
+++ b/apps/www/src/content/docs/components/combobox.md
@@ -82,7 +82,7 @@ const value = ref('')
               <Check
                 :class="cn(
                   'mr-2 h-4 w-4',
-                  value === framework.value ? 'opacity-100' : 'opacity-0',
+                  value?.value === framework.value ? 'opacity-100' : 'opacity-0',
                 )"
               />
               {{ framework.label }}

--- a/apps/www/src/content/docs/components/combobox.md
+++ b/apps/www/src/content/docs/components/combobox.md
@@ -62,7 +62,7 @@ const value = ref('')
         :aria-expanded="open"
         class="w-[200px] justify-between"
       >
-        {{ value ? frameworks.find((framework) => framework.value === value?.value)?.label : 'Select framework...' }}
+        {{ value ? frameworks.find((framework) => framework.value === value)?.label : 'Select framework...' }}
 
         <ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
       </Button>

--- a/apps/www/src/content/docs/components/combobox.md
+++ b/apps/www/src/content/docs/components/combobox.md
@@ -50,7 +50,7 @@ const frameworks = [
 ]
 
 const open = ref(false)
-const value = ref(null)
+const value = ref('')
 </script>
 
 <template>

--- a/apps/www/src/content/docs/components/combobox.md
+++ b/apps/www/src/content/docs/components/combobox.md
@@ -50,7 +50,7 @@ const frameworks = [
 ]
 
 const open = ref(false)
-const value = ref({})
+const value = ref(null)
 </script>
 
 <template>

--- a/apps/www/src/content/docs/components/combobox.md
+++ b/apps/www/src/content/docs/components/combobox.md
@@ -62,7 +62,7 @@ const value = ref(null)
         :aria-expanded="open"
         class="w-[200px] justify-between"
       >
-        {{ value ? frameworks.find((framework) => framework.value === value)?.label : 'Select framework...' }}
+        {{ value ? frameworks.find((framework) => framework.value === value?.value)?.label : 'Select framework...' }}
 
         <ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
       </Button>

--- a/apps/www/src/lib/registry/default/example/ComboboxDemo.vue
+++ b/apps/www/src/lib/registry/default/example/ComboboxDemo.vue
@@ -27,9 +27,7 @@ const frameworks = [
 ]
 
 const open = ref(false)
-const value = ref<string>('')
-
-// const filterFunction = (list: typeof frameworks, search: string) => list.filter(i => i.value.toLowerCase().includes(search.toLowerCase()))
+const value = ref('')
 </script>
 
 <template>

--- a/apps/www/src/lib/registry/new-york/example/ComboboxDemo.vue
+++ b/apps/www/src/lib/registry/new-york/example/ComboboxDemo.vue
@@ -27,9 +27,7 @@ const frameworks = [
 ]
 
 const open = ref(false)
-const value = ref<string>('')
-
-// const filterFunction = (list: typeof frameworks, search: string) => list.filter(i => i.value.toLowerCase().includes(search.toLowerCase()))
+const value = ref('')
 </script>
 
 <template>


### PR DESCRIPTION
The default value of `const value = ref({})` should contain a falsy value in order to show the "Select framework...".

![image](https://github.com/radix-vue/shadcn-vue/assets/6241164/04496c48-bfb3-47a7-a48b-3dce5b1d4c22)

![image](https://github.com/radix-vue/shadcn-vue/assets/6241164/71df90ec-e0e2-4e0e-9a14-2587a1312e34)

When giving it an `{}` empty object will result in a truthy value which is not what we want. When given an a falsy value like `null` it will display the correct text in the button.