### PR TITLE
fix(example): select language

### DIFF
--- a/apps/www/src/examples/forms/components/AccountForm.vue
+++ b/apps/www/src/examples/forms/components/AccountForm.vue
@@ -17,6 +17,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList,
 } from '@/lib/registry/default/ui/command'
 import { Button } from '@/lib/registry/new-york/ui/button'
 import {
@@ -146,26 +147,28 @@ async function onSubmit(values: any) {
           <PopoverContent class="w-[200px] p-0">
             <Command>
               <CommandInput placeholder="Search language..." />
-              <CommandEmpty>No framework found.</CommandEmpty>
-              <CommandGroup>
-                <CommandItem
-                  v-for="language in languages" :key="language.value" :value="language.label"
-                  @select="() => {
-                    setValues({
-                      language: language.value,
-                    })
-                    open = false
-                  }"
-                >
-                  <Check
-                    :class="cn(
-                      'mr-2 h-4 w-4',
-                      value === language.value ? 'opacity-100' : 'opacity-0',
-                    )"
-                  />
-                  {{ language.label }}
-                </CommandItem>
-              </CommandGroup>
+              <CommandEmpty>No language found.</CommandEmpty>
+              <CommandList>
+                <CommandGroup>
+                  <CommandItem
+                    v-for="language in languages" :key="language.value" :value="language.label"
+                    @select="() => {
+                      setValues({
+                        language: language.value,
+                      })
+                      open = false
+                    }"
+                  >
+                    <Check
+                      :class="cn(
+                        'mr-2 h-4 w-4',
+                        value === language.value ? 'opacity-100' : 'opacity-0',
+                      )"
+                    />
+                    {{ language.label }}
+                  </CommandItem>
+                </CommandGroup>
+              </CommandList>
             </Command>
           </PopoverContent>
         </Popover>


### PR DESCRIPTION
Hello, 

Just discovered that the language selector is a little broken now, so this little PR to fix it. 

**Before:**
![CleanShot 2024-03-28 at 20 12 26@2x](https://github.com/radix-vue/shadcn-vue/assets/10784316/25357182-e88b-4077-9f73-d08554062c40)

**After:**
![CleanShot 2024-03-28 at 20 14 28@2x](https://github.com/radix-vue/shadcn-vue/assets/10784316/e7742dd6-a86b-40ea-bce2-058fcc99d5d7)
![CleanShot 2024-03-28 at 20 14 59@2x](https://github.com/radix-vue/shadcn-vue/assets/10784316/9980446a-59d4-4a64-9e27-51fa17432190)
