### PR TITLE
Fix(example): wrong class at blocks example

### DIFF
--- a/apps/www/src/lib/registry/default/block/Authentication03.vue
+++ b/apps/www/src/lib/registry/default/block/Authentication03.vue
@@ -25,7 +25,7 @@ import { Label } from '@/lib/registry/default/ui/label'
     <CardContent>
       <div class="grid gap-4">
         <div class="grid grid-cols-2 gap-4">
-          <div class="space-y-2">
+          <div class="grid gap-2">
             <Label for="first-name">First name</Label>
             <Input id="first-name" placeholder="Max" required />
           </div>

--- a/apps/www/src/lib/registry/new-york/block/Authentication03.vue
+++ b/apps/www/src/lib/registry/new-york/block/Authentication03.vue
@@ -25,7 +25,7 @@ import { Label } from '@/lib/registry/new-york/ui/label'
     <CardContent>
       <div class="grid gap-4">
         <div class="grid grid-cols-2 gap-4">
-          <div class="space-y-2">
+          <div class="grid gap-2">
             <Label for="first-name">First name</Label>
             <Input id="first-name" placeholder="Max" required />
           </div>


### PR DESCRIPTION
Hello, found a small issue with the blocks example.

Before the fix:
<img width="423" alt="image" src="https://github.com/radix-vue/shadcn-vue/assets/23217571/43b853b1-75e1-41a1-b751-83c931b7bfe2">

after the fix:
<img width="460" alt="image" src="https://github.com/radix-vue/shadcn-vue/assets/23217571/a99c8523-8701-432d-9d52-bbfafd9122f4">
