### PR TITLE
refactor: delete grave accent(`) in template literals

### DIFF
--- a/apps/www/.vitepress/theme/components/BlockPreview.vue
+++ b/apps/www/.vitepress/theme/components/BlockPreview.vue
@@ -115,7 +115,7 @@ watch([style, codeConfig], async () => {
             class="mx-2 hidden h-4 md:flex"
           />
           <div class="flex items-center gap-2">
-            <a :href="`#${name}`">
+            <a :href="name">
               <Badge variant="outline">{{ name }}</Badge>
             </a>
             <Popover>


### PR DESCRIPTION
### Suggestion
- The name of props type is string.

```js
const props = defineProps<{
  name: string
}>()
```

<br/>

- so, grave accent(`) is unnecessary in template literals :)
- I suggest to delete grave accent(`) 

