### PR TITLE
docs: use the new `nuxi module add` command in installation

### DIFF
--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -23,7 +23,7 @@ npm install -D typescript
 ### Install TailwindCSS module
 
 ```bash
-npm install -D @nuxtjs/tailwindcss
+npx nuxi@latest module add @nuxtjs/tailwindcss
 ```
 
 ### Add `Nuxt` module
@@ -36,7 +36,7 @@ npm install -D @nuxtjs/tailwindcss
   Install the package below.
 
   ```bash
-  npm install -D shadcn-nuxt
+ npx nuxi@latest module add shadcn-nuxt
   ```
 
   </TabMarkdown>


### PR DESCRIPTION
This pull request is intended to update the documentation to use the `nuxi add` command, enhancing the developer experience by eliminating the need to manually add modules to `nuxt.config.ts`.