### PR TITLE
docs: prev button on second month

### DIFF
--- a/apps/www/src/lib/registry/default/example/DatePickerWithIndependentMonths.vue
+++ b/apps/www/src/lib/registry/default/example/DatePickerWithIndependentMonths.vue
@@ -219,9 +219,9 @@ watch(secondMonthPlaceholder, (_secondMonthPlaceholder) => {
                     'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
                   )
                 "
-                @click="updateMonth('second', 1)"
+                @click="updateMonth('second', -1)"
               >
-                <ChevronRight class="h-4 w-4" />
+                <ChevronLeft class="h-4 w-4" />
               </button>
               <div
                 :class="cn('text-sm font-medium')"

--- a/apps/www/src/lib/registry/new-york/example/DatePickerWithIndependentMonths.vue
+++ b/apps/www/src/lib/registry/new-york/example/DatePickerWithIndependentMonths.vue
@@ -217,9 +217,9 @@ watch(secondMonthPlaceholder, (_secondMonthPlaceholder) => {
                     'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
                   )
                 "
-                @click="updateMonth('second', 1)"
+                @click="updateMonth('second', -1)"
               >
-                <ChevronRight class="h-4 w-4" />
+                <ChevronLeft class="h-4 w-4" />
               </button>
               <div :class="cn('text-sm font-medium')">
                 {{


### PR DESCRIPTION
This PR fixes the `DatePicker` example with independent months having two next buttons for the second month.