### PR TITLE
docs: remove redundant placeholder prop

### DIFF
--- a/apps/www/src/lib/registry/default/example/DatePickerWithRange.vue
+++ b/apps/www/src/lib/registry/default/example/DatePickerWithRange.vue
@@ -49,7 +49,7 @@ const value = ref({
       </Button>
     </PopoverTrigger>
     <PopoverContent class="w-auto p-0">
-      <RangeCalendar v-model="value" initial-focus :number-of-months="2" :placeholder="value?.start" @update:start-value="(startDate) => value.start = startDate" />
+      <RangeCalendar v-model="value" initial-focus :number-of-months="2" @update:start-value="(startDate) => value.start = startDate" />
     </PopoverContent>
   </Popover>
 </template>

--- a/apps/www/src/lib/registry/new-york/example/DatePickerWithRange.vue
+++ b/apps/www/src/lib/registry/new-york/example/DatePickerWithRange.vue
@@ -49,7 +49,7 @@ const value = ref({
       </Button>
     </PopoverTrigger>
     <PopoverContent class="w-auto p-0">
-      <RangeCalendar v-model="value" initial-focus :number-of-months="2" :placeholder="value?.start" @update:start-value="(startDate) => value.start = startDate" />
+      <RangeCalendar v-model="value" initial-focus :number-of-months="2" @update:start-value="(startDate) => value.start = startDate" />
     </PopoverContent>
   </Popover>
 </template>


### PR DESCRIPTION
Hello,

This PR fixes #504.

The issue with the `RangeCalendar` breaking arises from the fact that the `placeholder` value must always be defined. Setting `placeholder` to `value?.start` makes it undefined when you reset the range, thus the errors in the issue.

Removing the `placeholder` prop from the examples fixes the issue. Also, setting the `placeholder` here is redundant due to how the `RangeCalendar` works internally (it always gets set to the range start value with `watch`).
