### PR TITLE
docs: Change controlled CommandDialog from prop to event

### DIFF
--- a/apps/www/src/content/docs/components/command.md
+++ b/apps/www/src/content/docs/components/command.md
@@ -101,7 +101,7 @@ watch(CmdJ, (v) => {
         <span class="text-xs">⌘</span>J
       </kbd>
     </p>
-    <CommandDialog :open="open" :on-open-change="handleOpenChange">
+    <CommandDialog :open="open" @update:open="handleOpenChange">
       <CommandInput placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>


### PR DESCRIPTION
Prop used in documentation :on-open-change, does not work and also seems to not exist in radix-vue Dialog component. So to properly control Dialog programmatically you need to use event @update:open.