### PR TITLE
docs: fix typo

### DIFF
--- a/apps/www/.vitepress/theme/config/docs.ts
+++ b/apps/www/.vitepress/theme/config/docs.ts
@@ -261,7 +261,7 @@ export const docsConfig: DocsConfig = {
           href: '/docs/components/pagination',
         },
         {
-          title: 'Pin Input',
+          title: 'PIN Input',
           href: '/docs/components/pin-input',
           items: [],
         },


### PR DESCRIPTION
This pull request made a minor change in the sidebar of shadcn-vue docs where `PIN Input` was misspelled as `Pin Input`.

[Documentation Page of PIN Input](https://www.shadcn-vue.com/docs/components/pin-input.html)