### PR TITLE
refactor: change `setValues` to `setFieldValue` for better validation

### DIFF
--- a/apps/www/src/content/docs/components/auto-form.md
+++ b/apps/www/src/content/docs/components/auto-form.md
@@ -414,9 +414,7 @@ const form = useForm({
   validationSchema: toTypedSchema(schema),
 })
 
-form.setValues({
-  username: 'foo'
-})
+form.setFieldValue('username', 'bar')
 </script>
 
 <template>

--- a/apps/www/src/examples/forms/components/AccountForm.vue
+++ b/apps/www/src/examples/forms/components/AccountForm.vue
@@ -84,7 +84,7 @@ async function onSubmit(values: any) {
     </p>
   </div>
   <Separator />
-  <Form v-slot="{ setValues }" :validation-schema="accountFormSchema" class="space-y-8" @submit="onSubmit">
+  <Form v-slot="{ setFieldValue }" :validation-schema="accountFormSchema" class="space-y-8" @submit="onSubmit">
     <FormField v-slot="{ componentField }" name="name">
       <FormItem>
         <FormLabel>Name</FormLabel>
@@ -126,15 +126,11 @@ async function onSubmit(values: any) {
               @update:model-value="(v) => {
                 if (v) {
                   dateValue = v
-                  setValues({
-                    dob: toDate(v).toISOString(),
-                  }, false)
+                  setFieldValue('dob', toDate(v).toISOString())
                 }
                 else {
                   dateValue = undefined
-                  setValues({
-                    dob: undefined,
-                  }, false)
+                  setFieldValue('dob', undefined)
                 }
               }"
             />
@@ -178,9 +174,7 @@ async function onSubmit(values: any) {
                   <CommandItem
                     v-for="language in languages" :key="language.value" :value="language.label"
                     @select="() => {
-                      setValues({
-                        language: language.value,
-                      }, false)
+                      setFieldValue('language', language.value)
                       open = false
                     }"
                   >

--- a/apps/www/src/lib/registry/default/example/CalendarForm.vue
+++ b/apps/www/src/lib/registry/default/example/CalendarForm.vue
@@ -32,7 +32,7 @@ const formSchema = toTypedSchema(z.object({
 
 const placeholder = ref()
 
-const { handleSubmit, setValues, values } = useForm({
+const { handleSubmit, setFieldValue, values } = useForm({
   validationSchema: formSchema,
 })
 
@@ -79,14 +79,10 @@ const onSubmit = handleSubmit((values) => {
               :max-value="today(getLocalTimeZone())"
               @update:model-value="(v) => {
                 if (v) {
-                  setValues({
-                    dob: v.toString(),
-                  })
+                  setFieldValue('dob', v.toString())
                 }
                 else {
-                  setValues({
-                    dob: '',
-                  })
+                  setFieldValue('dob', undefined)
                 }
               }"
             />

--- a/apps/www/src/lib/registry/default/example/ComboboxForm.vue
+++ b/apps/www/src/lib/registry/default/example/ComboboxForm.vue
@@ -48,7 +48,7 @@ const formSchema = toTypedSchema(z.object({
   }),
 }))
 
-const { handleSubmit, setValues, values } = useForm({
+const { handleSubmit, setFieldValue, values } = useForm({
   validationSchema: formSchema,
 })
 
@@ -91,9 +91,7 @@ const onSubmit = handleSubmit((values) => {
                     :key="language.value"
                     :value="language.label"
                     @select="() => {
-                      setValues({
-                        language: language.value,
-                      })
+                      setFieldValue('language', language.value)
                     }"
                   >
                     <Check

--- a/apps/www/src/lib/registry/default/example/DatePickerForm.vue
+++ b/apps/www/src/lib/registry/default/example/DatePickerForm.vue
@@ -32,7 +32,7 @@ const formSchema = toTypedSchema(z.object({
 
 const placeholder = ref()
 
-const { handleSubmit, setValues, values } = useForm({
+const { handleSubmit, setFieldValue, values } = useForm({
   validationSchema: formSchema,
   initialValues: {
 
@@ -82,14 +82,10 @@ const onSubmit = handleSubmit((values) => {
               :max-value="today(getLocalTimeZone())"
               @update:model-value="(v) => {
                 if (v) {
-                  setValues({
-                    dob: v.toString(),
-                  })
+                  setFieldValue('dob', v.toString())
                 }
                 else {
-                  setValues({
-                    dob: '',
-                  })
+                  setFieldValue('dob', undefined)
                 }
 
               }"

--- a/apps/www/src/lib/registry/new-york/example/CalendarForm.vue
+++ b/apps/www/src/lib/registry/new-york/example/CalendarForm.vue
@@ -32,7 +32,7 @@ const formSchema = toTypedSchema(z.object({
 
 const placeholder = ref()
 
-const { handleSubmit, setValues, values } = useForm({
+const { handleSubmit, setFieldValue, values } = useForm({
   validationSchema: formSchema,
 })
 
@@ -79,14 +79,10 @@ const onSubmit = handleSubmit((values) => {
               :max-value="today(getLocalTimeZone())"
               @update:model-value="(v) => {
                 if (v) {
-                  setValues({
-                    dob: v.toString(),
-                  })
+                  setFieldValue('dob', v.toString())
                 }
                 else {
-                  setValues({
-                    dob: '',
-                  })
+                  setFieldValue('dob', undefined)
                 }
               }"
             />

--- a/apps/www/src/lib/registry/new-york/example/ComboboxForm.vue
+++ b/apps/www/src/lib/registry/new-york/example/ComboboxForm.vue
@@ -48,7 +48,7 @@ const formSchema = toTypedSchema(z.object({
   }),
 }))
 
-const { handleSubmit, setValues, values } = useForm({
+const { handleSubmit, setFieldValue, values } = useForm({
   validationSchema: formSchema,
   initialValues: {
     language: '',
@@ -94,9 +94,7 @@ const onSubmit = handleSubmit((values) => {
                     :key="language.value"
                     :value="language.label"
                     @select="() => {
-                      setValues({
-                        language: language.value,
-                      })
+                      setFieldValue('language', language.value)
                     }"
                   >
                     {{ language.label }}

--- a/apps/www/src/lib/registry/new-york/example/DatePickerForm.vue
+++ b/apps/www/src/lib/registry/new-york/example/DatePickerForm.vue
@@ -32,7 +32,7 @@ const formSchema = toTypedSchema(z.object({
 
 const placeholder = ref()
 
-const { handleSubmit, setValues, values } = useForm({
+const { handleSubmit, setFieldValue, values } = useForm({
   validationSchema: formSchema,
   initialValues: {
 
@@ -82,16 +82,11 @@ const onSubmit = handleSubmit((values) => {
               :max-value="today(getLocalTimeZone())"
               @update:model-value="(v) => {
                 if (v) {
-                  setValues({
-                    dob: v.toString(),
-                  })
+                  setFieldValue('dob', v.toString())
                 }
                 else {
-                  setValues({
-                    dob: '',
-                  })
+                  setFieldValue('dob', undefined)
                 }
-
               }"
             />
           </PopoverContent>


### PR DESCRIPTION
In this PR changed all `setValues` to `setFieldValue` when we need to set only one field of form for better rules checking