### PR TITLE
fix: the broken navigation links for the code examples under the "Form" tab

### DIFF
--- a/apps/www/.vitepress/theme/components/ExamplesNav.vue
+++ b/apps/www/.vitepress/theme/components/ExamplesNav.vue
@@ -35,7 +35,7 @@ const examples = [
   },
   {
     name: 'Forms',
-    href: '/examples/forms/forms',
+    href: '/examples/forms',
     code: 'https://github.com/radix-vue/shadcn-vue/tree/dev/apps/www/src/examples/forms',
   },
   {


### PR DESCRIPTION
Go https://www.shadcn-vue.com/examples/forms/account.html and click `Views code`, then got incorrect href.