### PR TITLE
ci: use corepack to automatically handle pnpm version & use GitHub composite actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,16 @@
+name: Setup
+description: Installs Node, Enables Corepack and caches pnpm.
+
+runs:
+  using: composite
+
+  steps:
+    - name: Enable corepack
+      run: corepack enable
+      shell: bash
+
+    - name: Setup node & pnpm
+      uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+        cache: pnpm

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup (Install Node & pnpm)
         uses: ./.github/actions/setup

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,30 +50,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Run a build step here
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v2
-        with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        with:
-          version: 9.1.2
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+      - name: Setup (Install Node & pnpm)
+        uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: Setup (Install Node & pnpm)
         uses: ./.github/actions/setup
 
-      - run: npx changelogithub
+      - run: pnpm dlx changelogithub
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
+      - name: Setup (Install Node & pnpm)
+        uses: ./.github/actions/setup
 
       - run: npx changelogithub
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup (Install Node & pnpm)
         uses: ./.github/actions/setup

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,29 +21,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v2
-        with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        with:
-          version: 9.1.2
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+      - name: Setup (Install Node & pnpm)
+        uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile


### PR DESCRIPTION
Currently the pnpm version is hardcoded in workflows file and needs to be updated manually like this [`4fc463a` (#531)](https://github.com/radix-vue/shadcn-vue/pull/531/commits/4fc463a9b1892967edcd46ed32f9d6c03c2d726f) otherwise CI fails. 

This PR does the following
- Enables corepack which automatically uses the specified version by `packageManager` in `package.json`.
- Moves the shared setup (Installing node & enabling corepack) into a [GitHub Composite Action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) which is basically a reusable workflow that saves us duplication of steps across the workflows.
- Bumps `actions/checkout` to `v4` for consistency as both `v2` and `v3` were used in different workflows.
- Replaces `npx` with `pnpm dlx` in changelogithub script for consistency as we're using pnpm