### PR TITLE
fix(Form): added `name` to fieldState

### DIFF
--- a/apps/www/src/lib/registry/default/ui/form/useFormField.ts
+++ b/apps/www/src/lib/registry/default/ui/form/useFormField.ts
@@ -6,18 +6,18 @@ export function useFormField() {
   const fieldContext = inject(FieldContextKey)
   const fieldItemContext = inject(FORM_ITEM_INJECTION_KEY)
 
-  const fieldState = {
-    valid: useIsFieldValid(),
-    isDirty: useIsFieldDirty(),
-    isTouched: useIsFieldTouched(),
-    error: useFieldError(),
-  }
-
   if (!fieldContext)
     throw new Error('useFormField should be used within <FormField>')
 
   const { name } = fieldContext
   const id = fieldItemContext
+
+  const fieldState = {
+    valid: useIsFieldValid(name),
+    isDirty: useIsFieldDirty(name),
+    isTouched: useIsFieldTouched(name),
+    error: useFieldError(name),
+  }
 
   return {
     id,

--- a/apps/www/src/lib/registry/new-york/ui/form/useFormField.ts
+++ b/apps/www/src/lib/registry/new-york/ui/form/useFormField.ts
@@ -5,18 +5,19 @@ import { FORM_ITEM_INJECTION_KEY } from './injectionKeys'
 export function useFormField() {
   const fieldContext = inject(FieldContextKey)
   const fieldItemContext = inject(FORM_ITEM_INJECTION_KEY)
-  const fieldState = {
-    valid: useIsFieldValid(),
-    isDirty: useIsFieldDirty(),
-    isTouched: useIsFieldTouched(),
-    error: useFieldError(),
-  }
 
   if (!fieldContext)
     throw new Error('useFormField should be used within <FormField>')
 
   const { name } = fieldContext
   const id = fieldItemContext
+
+  const fieldState = {
+    valid: useIsFieldValid(name),
+    isDirty: useIsFieldDirty(name),
+    isTouched: useIsFieldTouched(name),
+    error: useFieldError(name),
+  }
 
   return {
     id,


### PR DESCRIPTION
update `useFormField` function `fieldState` definition

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

On my own project, I had a problem with `useFormField`; there are no changes inside the `FormControl` component, `aria-invalid` property remains unchanged, but errors were inside the `errors` object returned from `useForm` vee-validate. Some time was needed to find the problem, and it was inside the `useFormField` function, where `fieldState` was just generated with `useFieldError`, for example, without passing the `name` inside. After just adding `name`, everything worked fine. This occurred on custom phone input with select and input that only receives the `:name` property from the parent slot.

### 📸 Screenshots (if appropriate)

<img width="429" alt="image" src="https://github.com/radix-vue/shadcn-vue/assets/82209198/147a7def-42b1-4bb6-a98a-5ba60d95858a">

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
