### PR TITLE
docs: Add @internationalized/date package to installation instruction

### DIFF
--- a/apps/www/src/content/docs/components/calendar.md
+++ b/apps/www/src/content/docs/components/calendar.md
@@ -24,6 +24,10 @@ If you're looking for a range calendar, check out the [Range Calendar](/docs/com
 ```bash
 npx shadcn-vue@latest add calendar
 ```
+::: tip
+The component depends on the [@internationalized/date](https://react-spectrum.adobe.com/internationalized/date/index.html) package, which solves a lot of the problems that come with working with dates and times in JavaScript.
+Check [Dates & Times in Radix Vue](https://www.radix-vue.com/guides/dates.html) for more information and installation instructions.
+:::
 
 ## Datepicker
 


### PR DESCRIPTION
### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've added the [@internationalized/date](https://react-spectrum.adobe.com/internationalized/date/index.html) package to the installation instructions as it is not mentioned anywhere in the Shadcn-Vue docs which got me quite confused at first.


- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
