### PR TITLE
docs: add comment how to enable transitions when switching theme mode

### DIFF
--- a/apps/www/src/content/docs/dark-mode/vite.md
+++ b/apps/www/src/content/docs/dark-mode/vite.md
@@ -32,7 +32,8 @@ import { Icon } from '@iconify/vue'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 
-const mode = useColorMode()
+// Pass { disableTransition: false } to enable transitions
+const mode = useColorMode();
 </script>
 
 <template>


### PR DESCRIPTION
useColorMode disables transitions by default .

<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

No issues.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add comment in code example how to enable transitions (since there are transitions for icons included) when switching theme mode.
By default transitions are disabled and if anyone is not familiar with Vue useColorMode (I wasn't) this could be helpful so they don't report false issues or search for the problem.

### 📸 Screenshots (if appropriate)

No need.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
