### PR TITLE
fix: changed color of stepper component icons

### DIFF
--- a/apps/www/src/lib/registry/default/ui/stepper/StepperIndicator.vue
+++ b/apps/www/src/lib/registry/default/ui/stepper/StepperIndicator.vue
@@ -20,7 +20,7 @@ const forwarded = useForwardProps(delegatedProps)
   <StepperIndicator
     v-bind="forwarded"
     :class="cn(
-      'inline-flex items-center justify-center rounded-full text-white w-10 h-10',
+      'inline-flex items-center justify-center rounded-full text-muted-foreground/50 w-10 h-10',
       // Disabled
       'group-data-[disabled]:text-muted-foreground group-data-[disabled]:opacity-50',
       // Active


### PR DESCRIPTION
# changed color of stepper component icons

### 🔗 https://github.com/radix-vue/shadcn-vue/issues/675

issue #675 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There was a bug in the color of an icon in the light mode of the stepper component, which needed to be fixed to make the component look better to the user.

Resolves #675 

### 📸 Screenshots

## Before
![Captura de pantalla 2024-07-24 084504](https://github.com/user-attachments/assets/82d34eba-605f-4b01-b4e6-12d75d75681e)

## Now
![Captura de pantalla 2024-07-24 140409](https://github.com/user-attachments/assets/e9e9131e-60b8-4bfd-b90d-16af5df37483)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
