### PR TITLE
fix(command): add generic

### DIFF
--- a/apps/www/src/examples/dashboard/components/TeamSwitcher.vue
+++ b/apps/www/src/examples/dashboard/components/TeamSwitcher.vue
@@ -92,7 +92,7 @@ const selectedTeam = ref<Team>(groups[0].teams[0])
         </Button>
       </PopoverTrigger>
       <PopoverContent class="w-[200px] p-0">
-        <Command :filter-function="(list, term) => list.filter(i => i.label?.toLowerCase()?.includes(term)) ">
+        <Command :filter-function="(list:typeof groups, term:string) => list.filter(i => i.label?.toLowerCase()?.includes(term)) ">
           <CommandList>
             <CommandInput placeholder="Search team..." />
             <CommandEmpty>No team found.</CommandEmpty>

--- a/apps/www/src/lib/registry/default/ui/command/Command.vue
+++ b/apps/www/src/lib/registry/default/ui/command/Command.vue
@@ -1,12 +1,15 @@
-<script setup lang="ts">
+<script lang="ts">
+type AcceptableValue = string | number | boolean | Record<string, any>
+</script>
+
+<script setup lang="ts"  generic="T extends AcceptableValue">
 import { type HTMLAttributes, computed } from 'vue'
 import type { ComboboxRootEmits, ComboboxRootProps } from 'radix-vue'
 import { ComboboxRoot, useForwardPropsEmits } from 'radix-vue'
 import { cn } from '@/lib/utils'
 
-const props = withDefaults(defineProps<ComboboxRootProps & { class?: HTMLAttributes['class'] }>(), {
+const props = withDefaults(defineProps<ComboboxRootProps<T> & { class?: HTMLAttributes['class'] }>(), {
   open: true,
-  modelValue: '',
 })
 
 const emits = defineEmits<ComboboxRootEmits>()

--- a/apps/www/src/lib/registry/new-york/ui/command/Command.vue
+++ b/apps/www/src/lib/registry/new-york/ui/command/Command.vue
@@ -1,12 +1,15 @@
-<script setup lang="ts">
+<script lang="ts">
+type AcceptableValue = string | number | boolean | Record<string, any>
+</script>
+
+<script setup lang="ts" generic="T extends AcceptableValue">
 import { type HTMLAttributes, computed } from 'vue'
 import type { ComboboxRootEmits, ComboboxRootProps } from 'radix-vue'
 import { ComboboxRoot, useForwardPropsEmits } from 'radix-vue'
 import { cn } from '@/lib/utils'
 
-const props = withDefaults(defineProps<ComboboxRootProps & { class?: HTMLAttributes['class'] }>(), {
+const props = withDefaults(defineProps<ComboboxRootProps<T> & { class?: HTMLAttributes['class'] }>(), {
   open: true,
-  modelValue: '',
 })
 
 const emits = defineEmits<ComboboxRootEmits>()


### PR DESCRIPTION
### 🔗 Linked issue
#327 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Generic component secondary packaging requires passing the corresponding constraints. Otherwise, complex types such as filter-function will not recognize the type.

The following filter-function in several files has type errors before modification

apps/www/src/examples/dashboard/components/TeamSwitcher.vue apps/www/src/examples/tasks/components/DataTableFacetedFilter.vue apps/www/src/lib/registry/default/example/CardChat.vue 
apps/www/src/lib/registry/new-york/example/CardChat.vue

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.