### PR TITLE
docs: Navigation Menu Nuxt Link Example fixed

### DIFF
--- a/apps/www/src/content/docs/components/navigation-menu.md
+++ b/apps/www/src/content/docs/components/navigation-menu.md
@@ -56,10 +56,8 @@ import { navigationMenuTriggerStyle } from '@/components/ui/navigation-menu'
 ```vue
 <template>
   <NavigationMenuItem>
-    <NuxtLink to="/docs">
-      <NavigationMenuLink :class="navigationMenuTriggerStyle()">
+    <NuxtLink to="/docs" :class="navigationMenuTriggerStyle()">
         Documentation
-      </NavigationMenuLink>
     </NuxtLink>
   </NavigationMenuItem>
 </template>

--- a/apps/www/src/content/docs/components/navigation-menu.md
+++ b/apps/www/src/content/docs/components/navigation-menu.md
@@ -56,8 +56,10 @@ import { navigationMenuTriggerStyle } from '@/components/ui/navigation-menu'
 ```vue
 <template>
   <NavigationMenuItem>
-    <NuxtLink to="/docs" :class="navigationMenuTriggerStyle()">
+    <NuxtLink v-slot="{ isActive, href, navigate }" to="/docs" custom>
+      <NavigationMenuLink :active="isActive" :href :class="navigationMenuTriggerStyle()" @click="navigate">
         Documentation
+      </NavigationMenuLink>
     </NuxtLink>
   </NavigationMenuItem>
 </template>


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There is currently hydration issues with Nuxt which can kinda be fixed using the useId function and ConfigProvider in app.vue but implementing the Navigation Menu with NuxtLinks like shown currently in the docs, is throwing hydration errors anyways, so the correct way to do it without errors is to apply the classes directly onto the NuxtLink and remove the second Link element.

How it's shown in the docs currently:
```html
<template>
  <NavigationMenuItem>
    <NuxtLink to="/docs">
      <NavigationMenuLink :class="navigationMenuTriggerStyle()">
        Documentation
      </NavigationMenuLink>
    </NuxtLink>
  </NavigationMenuItem>
</template>
```

Correct implementation:
```html
<template>
  <NavigationMenuItem>
    <NuxtLink to="/docs" :class="navigationMenuTriggerStyle()">
        Documentation
    </NuxtLink>
  </NavigationMenuItem>
</template>
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
