### PR TITLE
feat: auto install `@nuxtjs/color-mode` module

### DIFF
--- a/apps/www/src/content/docs/dark-mode/nuxt.md
+++ b/apps/www/src/content/docs/dark-mode/nuxt.md
@@ -7,7 +7,7 @@ description: Adding dark mode to your nuxt app.
 
 <Steps>
 
-### Install Dependencies
+<!-- ### Install Dependencies
 
 ```bash
 npm install -D @nuxtjs/color-mode
@@ -25,18 +25,20 @@ export default defineNuxtConfig({
     classSuffix: ''
   }
 })
-```
-
-Optional, to include icons for theme button.
-```bash
-npm install -D @iconify/vue @iconify-json/radix-icons
-```
+``` -->
 
 ### Add a mode toggle
 
 Place a mode toggle on your site to toggle between light and dark mode.
 
+The `@nuxtjs/color-mode` module is automatically installed and configured during the installation of the `shadcn-nuxt` module, so you literally have nothing to do.
+
 We're using [`useColorMode`](https://color-mode.nuxtjs.org/#usage) from [`Nuxt Color Mode`](https://color-mode.nuxtjs.org/).
+
+Optional, to include icons for theme button.
+```bash
+npm install -D @iconify/vue @iconify-json/radix-icons
+```
 
 ```vue
 <script setup lang="ts">

--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { parseSync } from '@oxc-parser/wasm'
-import { addComponent, addTemplate, createResolver, defineNuxtModule, findPath, useLogger } from '@nuxt/kit'
+import { addComponent, addTemplate, createResolver, defineNuxtModule, findPath, installModule, useLogger } from '@nuxt/kit'
 import { UTILS } from '../../cli/src/utils/templates'
 
 // TODO: add test to make sure all registry is being parse correctly
@@ -59,6 +59,14 @@ export default defineNuxtModule<ModuleOptions>({
       })
     })
 
+    // Installs the `@nuxtjs/color-mode` module.
+
+    await installModule('@nuxtjs/color-mode', {
+      colorMode: {
+        classSuffix: '',
+      },
+    })
+
     // Manually scan `componentsDir` for components and register them for auto imports
     try {
       readdirSync(resolve(COMPONENT_DIR_PATH))
@@ -73,7 +81,7 @@ export default defineNuxtModule<ModuleOptions>({
 
             const exportedKeys: string[] = ast.program.body
               .filter(node => node.type === 'ExportNamedDeclaration')
-            // @ts-expect-error parse return any
+              // @ts-expect-error parse return any
               .flatMap(node => node.specifiers.map(specifier => specifier.exported.name))
               .filter((key: string) => /^[A-Z]/.test(key))
 


### PR DESCRIPTION
Issue: #537

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request is intended to install the `@nuxtjs/color-mode` module alongside the installation of the `shadcn-nuxt` module. Why do so? Adding dark mode functionality has become a standard practice for many developers using Shadcn Vue in their web apps. To enhance developer experience (DX), it would be highly beneficial if the `@nuxtjs/color-mode` module were pre-installed and automatically configured.

Closes: #537

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
