### PR TITLE
docs(components): update calendar year-month select example

### DIFF
--- a/apps/www/src/lib/registry/default/example/CalendarWithSelect.vue
+++ b/apps/www/src/lib/registry/default/example/CalendarWithSelect.vue
@@ -72,7 +72,7 @@ const formatter = useDateFormatter('en')
         </Select>
 
         <Select
-          :default-value="props.placeholder.year.toString()"
+          :default-value="placeholder.year.toString()"
           @update:model-value="(v) => {
             if (!v || !placeholder) return;
             if (Number(v) === placeholder?.year) return;

--- a/apps/www/src/lib/registry/new-york/example/CalendarWithSelect.vue
+++ b/apps/www/src/lib/registry/new-york/example/CalendarWithSelect.vue
@@ -72,7 +72,7 @@ const formatter = useDateFormatter('en')
         </Select>
 
         <Select
-          :default-value="props.placeholder.year.toString()"
+          :default-value="placeholder.year.toString()"
           @update:model-value="(v) => {
             if (!v || !placeholder) return;
             if (Number(v) === placeholder?.year) return;


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->


<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR updates the [Month & Year Selects](https://www.shadcn-vue.com/docs/components/calendar.html#month-year-selects) examples year select `default-value` prop to use `placeholder.year` instead of `props.placeholder.year`.

In the current example default year value is always the current year or a value that is passed on from `placeholder` prop and does not consider `v-model` value like the month select does.

With this change the year select will display value from `v-model` if applicable.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
