### PR TITLE
docs: replace lucide-react with lucide-vue-next

### DIFF
--- a/apps/www/.vitepress/theme/components/BlockPreview.vue
+++ b/apps/www/.vitepress/theme/components/BlockPreview.vue
@@ -187,7 +187,7 @@ watch([style, codeConfig], async () => {
             </p>
             <p>
               The <span class="font-medium">Default</span> style has
-              larger inputs, uses lucide-react for icons and
+              larger inputs, uses lucide-vue-next for icons and
               tailwindcss-animate for animations.
             </p>
             <p>

--- a/apps/www/src/content/docs/components/breadcrumb.md
+++ b/apps/www/src/content/docs/components/breadcrumb.md
@@ -58,7 +58,7 @@ Use a custom component as `slot` for `<BreadcrumbSeparator />` to create a custo
 
 ```vue showLineNumbers {2,20-22}
 <script setup lang="ts">
-import { Slash } from 'lucide-react'
+import { Slash } from 'lucide-vue-next'
 import {
   Breadcrumb,
   BreadcrumbItem,


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fixed a typo in the documentation on the [Breadcrumbs](https://www.shadcn-vue.com/docs/components/breadcrumb.html) page and `BlockPreview.vue` component by replacing `lucide-react` with `lucide-vue-next`.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
