### PR TITLE
docs: add “w-full h-full” to AspectRatio component example for proper display

### DIFF
--- a/apps/www/src/content/docs/components/aspect-ratio.md
+++ b/apps/www/src/content/docs/components/aspect-ratio.md
@@ -46,7 +46,7 @@ import { AspectRatio } from '@/components/ui/aspect-ratio'
 <template>
   <div class="w-[450px]">
     <AspectRatio :ratio="16 / 9">
-      <img src="..." alt="Image" class="rounded-md object-cover">
+      <img src="..." alt="Image" class="rounded-md object-cover w-full h-full">
     </AspectRatio>
   </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

No open issue, since it's a minor docs fix.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Added w-full h-full to the img element in the AspectRatio component example.
- Without these classes, the image did not fill the container as expected when using the AspectRatio component.
- This ensures that the image will correctly scale within the given aspect ratio, filling the entire container.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
