### PR TITLE
docs: expand TailwindCSS installation instructions to address module installation error

### DIFF
--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -33,6 +33,22 @@ npm install -D typescript
 npx nuxi@latest module add @nuxtjs/tailwindcss
 ```
 
+Alternatively, you can manually add `@nuxtjs/tailwindcss` using your dependency manager
+
+```bash
+npm install --save-dev @nuxtjs/tailwindcss
+```
+
+and then to the `modules` section of `nuxt.config.{ts,js}`
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxtjs/tailwindcss'
+  ]
+})
+```
+
 ### Add `Nuxt` module
 
 <br>


### PR DESCRIPTION
### 🔗 Linked issue

[#803](https://github.com/unovue/shadcn-vue/issues/803)

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR expands the TailwindCSS installation instructions to include important troubleshooting steps. From time to time, the Nuxt module installation throws the following error:

```bash
$ npx nuxi@latest module add tailwindcss

 ERROR  [GET] "https://npm.fontawesome.com/@nuxtjs/tailwindcss/latest": 401 Unauthorized                                              8:39:48 a.m.

  at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
  at async $fetch2 (/C:/Users/ryanr/AppData/Local/npm-cache/_npx/b95349761371180e/node_modules/nuxi/dist/shared/nuxi.b88e7b0f.mjs:340:15)
  at async resolveModule (/C:/Users/ryanr/AppData/Local/npm-cache/_npx/b95349761371180e/node_modules/nuxi/dist/chunks/add2.mjs:262:15)
  at async Object.setup (/C:/Users/ryanr/AppData/Local/npm-cache/_npx/b95349761371180e/node_modules/nuxi/dist/chunks/add2.mjs:136:15)
  at async runCommand$1 (/C:/Users/ryanr/AppData/Local/npm-cache/_npx/b95349761371180e/node_modules/nuxi/dist/shared/nuxi.3e201632.mjs:1620:5)
  at async runCommand$1 (/C:/Users/ryanr/AppData/Local/npm-cache/_npx/b95349761371180e/node_modules/nuxi/dist/shared/nuxi.3e201632.mjs:1639:11)
  at async runCommand$1 (/C:/Users/ryanr/AppData/Local/npm-cache/_npx/b95349761371180e/node_modules/nuxi/dist/shared/nuxi.3e201632.mjs:1639:11)
  at async runMain$1 (/C:/Users/ryanr/AppData/Local/npm-cache/_npx/b95349761371180e/node_modules/nuxi/dist/shared/nuxi.3e201632.mjs:1777:7) 
```

This error occurs due to an unauthorized 401 response from the FontAwesome URL. To resolve this issue, the manual installation of the TailwindCSS package and adding it to the config are required. This additional information is crucial to avoid installation interruptions and ensure a smooth setup process for developers using Nuxt with TailwindCSS.

This change improves the installation process and prevents potential roadblocks for developers.

Linked issue: #803

### 📸 Screenshots (if appropriate)

Simply following the lead of the Nuxt Tailwind Module as a guide for what should be included in the instructions for this step.
![image](https://github.com/user-attachments/assets/64ec5912-b772-4ad3-9c2f-f109d07a5004)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
