### PR TITLE
docs: update footer links

### DIFF
--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -41,7 +41,7 @@ const toggleDark = useToggle(isDark)
 const links = [
   {
     name: 'GitHub',
-    href: 'https://github.com/radix-vue/shadcn-vue',
+    href: 'https://github.com/unovue/shadcn-vue',
     icon: RadixIconsGithubLogo,
   },
   // {
@@ -220,7 +220,7 @@ watch(() => $route.path, (n) => {
             <span class="inline-block ml-2">
               The code source is available on
               <a
-                href="https://github.com/radix-vue/shadcn-vue"
+                href="https://github.com/unovue/shadcn-vue"
                 target="_blank"
                 class="underline underline-offset-4 font-bold decoration-foreground"
               >


### PR DESCRIPTION
I'm not sure if [this part](https://github.com/unovue/shadcn-vue/blob/dev/apps/www/.vitepress/theme/layout/MainLayout.vue#L212) is correct:

`Ported to Vue by https://github.com/radix-vue`