### PR TITLE
fix(types): add explicit return type for useToast to resolve ts(2742)…

### DIFF
--- a/apps/www/src/lib/registry/default/ui/toast/use-toast.ts
+++ b/apps/www/src/lib/registry/default/ui/toast/use-toast.ts
@@ -1,4 +1,4 @@
-import type { Component, VNode } from 'vue'
+import type { Component, ComputedRef, VNode } from 'vue'
 import type { ToastProps } from '.'
 import { computed, ref } from 'vue'
 
@@ -119,6 +119,16 @@ function dispatch(action: Action) {
 
       break
   }
+}
+
+interface UseToast {
+  dismiss: (toastId?: string) => void
+  toast: (props: Toast) => {
+    dismiss: () => void
+    id: string
+    update: (props: ToasterToast) => void
+  }
+  toasts: ComputedRef<ToasterToast[]>
 }
 
 function useToast() {

--- a/apps/www/src/lib/registry/new-york/ui/toast/use-toast.ts
+++ b/apps/www/src/lib/registry/new-york/ui/toast/use-toast.ts
@@ -1,4 +1,4 @@
-import type { Component, VNode } from 'vue'
+import type { Component, ComputedRef, VNode } from 'vue'
 import type { ToastProps } from '.'
 import { computed, ref } from 'vue'
 
@@ -120,6 +120,17 @@ function dispatch(action: Action) {
       break
   }
 }
+
+interface UseToast {
+  dismiss: (toastId?: string) => void
+  toast: (props: Toast) => {
+    dismiss: () => void
+    id: string
+    update: (props: ToasterToast) => void
+  }
+  toasts: ComputedRef<ToasterToast[]>
+}
+
 
 function useToast() {
   return {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR resolves the TypeScript error ts(2742), which caused an issue with the inferred type of the useToast function in the use-toast.ts file. The error was due to the inferred type depending on an internal @vue/shared reference, making it non-portable.

Added an explicit return type for the useToast function to ensure the type is portable and compatible with the project's type-checking settings.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

N/A
<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
