### PR TITLE
fix(nuxt_module): component override warnings

### DIFF
--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -90,6 +90,7 @@ export default defineNuxtModule<ModuleOptions>({
                 name: `${prefix}${key}`, // name of the component to be used in vue templates
                 export: key, // (optional) if the component is a named (rather than default) export
                 filePath: resolve(filePath),
+                priority: 1
               })
             })
           }


### PR DESCRIPTION
### 🔗 Linked issue
fix: https://github.com/unovue/shadcn-vue/issues/818

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a Nuxt 3 component overwrite warning due to missing priority value `WARN  Overriding X component. You can specify a priority option when calling addComponent to avoid this warning.`

Set to 1 as default is depicted [here](https://nuxt.com/docs/api/kit/components)

If the overwrite should actually happen is a different question, so maybe this PR is not adequate as it probably only fixes the outcome and not the source.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
