### PR TITLE
fix(SidebarMenuAction): add slot into component

### DIFF
--- a/apps/www/src/lib/registry/default/ui/sidebar/SidebarMenuAction.vue
+++ b/apps/www/src/lib/registry/default/ui/sidebar/SidebarMenuAction.vue
@@ -28,5 +28,7 @@ const props = withDefaults(defineProps<PrimitiveProps & {
     )"
     :as="as"
     :as-child="asChild"
-  />
+  >
+    <slot/>
+  </Primitive>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/sidebar/SidebarMenuAction.vue
+++ b/apps/www/src/lib/registry/new-york/ui/sidebar/SidebarMenuAction.vue
@@ -28,5 +28,7 @@ const props = withDefaults(defineProps<PrimitiveProps & {
     )"
     :as="as"
     :as-child="asChild"
-  />
+  >
+    <slot/>
+  </Primitive>
 </template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Component `SidebarMenuAction` doesn't render child components. Adding `<slot/>` will allow you to pass your own content into `SidebarMenuAction`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
