### PR TITLE
feat(Sidebar): add minScreen prop

### DIFF
--- a/apps/www/src/lib/registry/default/ui/sidebar/Sidebar.vue
+++ b/apps/www/src/lib/registry/default/ui/sidebar/Sidebar.vue
@@ -13,11 +13,13 @@ const props = withDefaults(defineProps<{
   side?: 'left' | 'right'
   variant?: 'sidebar' | 'floating' | 'inset'
   collapsible?: 'offcanvas' | 'icon' | 'none'
+  minScreen?: 'sm' | 'md' | 'lg'
   class?: HTMLAttributes['class']
 }>(), {
   side: 'left',
   variant: 'sidebar',
   collapsible: 'offcanvas',
+  minScreen: 'md',
 })
 
 const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
@@ -53,6 +55,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     :data-collapsible="state === 'collapsed' ? collapsible : ''"
     :data-variant="variant"
     :data-side="side"
+    :class="{ 'sm:block': minScreen === 'sm', 'md:block': minScreen === 'md', 'lg:block': minScreen === 'lg' }"
   >
     <!-- This is what handles the sidebar gap on desktop  -->
     <div
@@ -75,6 +78,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
         variant === 'floating' || variant === 'inset'
           ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]'
           : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l',
+        { 'sm:block': minScreen === 'sm', 'md:block': minScreen === 'md', 'lg:block': minScreen === 'lg' },
         props.class,
       )"
       v-bind="$attrs"

--- a/apps/www/src/lib/registry/new-york/ui/sidebar/Sidebar.vue
+++ b/apps/www/src/lib/registry/new-york/ui/sidebar/Sidebar.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<{
   side: 'left',
   variant: 'sidebar',
   collapsible: 'offcanvas',
-  minScreen: 'md'
+  minScreen: 'md',
 })
 
 const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
@@ -78,7 +78,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
         variant === 'floating' || variant === 'inset'
           ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]'
           : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l',
-        { 'sm:block': minScreen === 'sm', 'md:block': minScreen === 'md', 'lg:block': minScreen === 'lg' }
+        { 'sm:block': minScreen === 'sm', 'md:block': minScreen === 'md', 'lg:block': minScreen === 'lg' },
         props.class,
       )"
       v-bind="$attrs"

--- a/apps/www/src/lib/registry/new-york/ui/sidebar/Sidebar.vue
+++ b/apps/www/src/lib/registry/new-york/ui/sidebar/Sidebar.vue
@@ -13,11 +13,13 @@ const props = withDefaults(defineProps<{
   side?: 'left' | 'right'
   variant?: 'sidebar' | 'floating' | 'inset'
   collapsible?: 'offcanvas' | 'icon' | 'none'
+  minScreen?: 'sm' | 'md' | 'lg'
   class?: HTMLAttributes['class']
 }>(), {
   side: 'left',
   variant: 'sidebar',
   collapsible: 'offcanvas',
+  minScreen: 'md'
 })
 
 const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
@@ -53,6 +55,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     :data-collapsible="state === 'collapsed' ? collapsible : ''"
     :data-variant="variant"
     :data-side="side"
+    :class="{ 'sm:block': minScreen === 'sm', 'md:block': minScreen === 'md', 'lg:block': minScreen === 'lg' }"
   >
     <!-- This is what handles the sidebar gap on desktop  -->
     <div
@@ -75,6 +78,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
         variant === 'floating' || variant === 'inset'
           ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]'
           : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l',
+        { 'sm:block': minScreen === 'sm', 'md:block': minScreen === 'md', 'lg:block': minScreen === 'lg' }
         props.class,
       )"
       v-bind="$attrs"


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently Sidebar component doesn't allow to set the screen size for display the sidebar as sidebar or sidepage. By default screen size `all <= md` is sidepage and `md > all` is sidebar.
Property `minScreen` will allow to set min screen size when sidebar switches from sidepage to sidebar.
p.s. sidepage (mobile), sidebar(desktop)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
