### PR TITLE
refactor: init CLI and @nuxtjs/color-mode module config

### DIFF
--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -27,28 +27,6 @@ If you encounter the error `ERROR: Cannot read properties of undefined (reading 
 npm install -D typescript
 ```
 
-### Install TailwindCSS module
-
-```bash
-npx nuxi@latest module add @nuxtjs/tailwindcss
-```
-
-Alternatively, you can manually add `@nuxtjs/tailwindcss` using your dependency manager
-
-```bash
-npm install --save-dev @nuxtjs/tailwindcss
-```
-
-and then to the `modules` section of `nuxt.config.{ts,js}`
-
-```ts
-export default defineNuxtConfig({
-  modules: [
-    '@nuxtjs/tailwindcss'
-  ]
-})
-```
-
 ### Add `Nuxt` module
 
 <br>
@@ -56,7 +34,7 @@ export default defineNuxtConfig({
 <TabsMarkdown>
   <TabMarkdown title="shadcn-nuxt">
 
-  Install the package below.
+Installing the `shadcn-nuxt` module automatically installs and configures `@nuxtjs/tailwindcss` and `@nuxtjs/color-mode` modules.
 
   ```bash
  npx nuxi@latest module add shadcn-nuxt
@@ -179,6 +157,35 @@ declare module '@nuxt/schema' {
 }
 ```
 
+### Install TailwindCss
+
+  ```bash
+npx nuxi@latest module add @nuxtjs/tailwindcss
+  ```
+
+If not configured automatically in the `nuxt.config.ts` file, configure it as shown below:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/tailwindcss'],
+})
+```
+
+### Install Color Mode
+
+  ```bash
+npx nuxi module add color-mode
+  ```
+
+If not configured automatically in the `nuxt.config.ts` file, configure it as shown below:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['...', '@nuxtjs/color-mode'],
+  classSuffix: ''
+})
+```
+
   </TabMarkdown>
 </TabsMarkdown>
 
@@ -186,7 +193,7 @@ declare module '@nuxt/schema' {
 
 ```ts
 export default defineNuxtConfig({
-  modules: ['@nuxtjs/tailwindcss', 'shadcn-nuxt'],
+  modules: ['shadcn-nuxt'],
   shadcn: {
     /**
      * Prefix for all the imported component

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander'
 import { consola } from 'consola'
 import { colors } from 'consola/utils'
 import { template } from 'lodash-es'
-import { addDependency } from 'nypm'
+import { addDependency, addDevDependency } from 'nypm'
 import ora from 'ora'
 import path from 'pathe'
 import prompts from 'prompts'
@@ -38,6 +38,9 @@ const PROJECT_DEPENDENCIES = {
     'clsx',
     'tailwind-merge',
     'radix-vue',
+  ],
+  nuxt: [
+    'shadcn-nuxt',
   ],
 }
 
@@ -309,10 +312,21 @@ export async function runInit(cwd: string, config: Config) {
   const iconsDep = config.style === 'new-york' ? ['@radix-icons/vue'] : ['lucide-vue-next']
   const deps = PROJECT_DEPENDENCIES.base.concat(iconsDep).filter(Boolean)
 
-  await addDependency(deps, {
-    cwd,
-    silent: true,
-  })
+  await Promise.allSettled(
+    [
+      config.framework === 'nuxt' && await addDevDependency(
+        [...PROJECT_DEPENDENCIES.nuxt, ...deps],
+        {
+          cwd,
+          silent: true,
+        },
+      ),
+      await addDependency(deps, {
+        cwd,
+        silent: true,
+      }),
+    ],
+  )
 
   dependenciesSpinner?.succeed()
 }

--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -63,7 +63,7 @@ export default defineNuxtModule<ModuleOptions>({
     await installModule('@nuxtjs/tailwindcss')
 
     // Installs the `@nuxtjs/color-mode` module.
-    await installModule('@nuxtjs/color-mode')
+    await installModule('@nuxtjs/color-mode', { classSuffix: '' })
 
     // Manually scan `componentsDir` for components and register them for auto imports
     try {


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Fixes: #864

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request is intended to do two things namely:

1. **Configure the @nuxtjs/color-mode module by adding the `classSuffix: ''` property as shown below:** 
`await installModule('@nuxtjs/color-mode', { classSuffix: '' })`.

2. **Refactor the init CLI by ensuring that the `shadcn-nuxt` module is installed when the selected framework is Nuxt and the base dependencies as well.**


### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
