### PR TITLE
feat: Take the max property into consideration in Progress

### DIFF
--- a/apps/www/src/content/docs/components/progress.md
+++ b/apps/www/src/content/docs/components/progress.md
@@ -44,6 +44,6 @@ import { Progress } from '@/components/ui/progress'
 </script>
 
 <template>
-  <Progress :model-value="33" />
+  <Progress :model-value="33" :max="50" />
 </template>
 ```

--- a/apps/www/src/lib/registry/default/ui/progress/Progress.vue
+++ b/apps/www/src/lib/registry/default/ui/progress/Progress.vue
@@ -11,6 +11,7 @@ const props = withDefaults(
   defineProps<ProgressRootProps & { class?: HTMLAttributes['class'] }>(),
   {
     modelValue: 0,
+    max: 100
   },
 )
 
@@ -33,7 +34,7 @@ const delegatedProps = computed(() => {
   >
     <ProgressIndicator
       class="h-full w-full flex-1 bg-primary transition-all"
-      :style="`transform: translateX(-${100 - (props.modelValue ?? 0) * 100 / (props.max ?? 100)}%);`"
+      :style="`transform: translateX(-${100 - (props.modelValue ?? 0) * 100 / props.max}%);`"
     />
   </ProgressRoot>
 </template>

--- a/apps/www/src/lib/registry/default/ui/progress/Progress.vue
+++ b/apps/www/src/lib/registry/default/ui/progress/Progress.vue
@@ -33,7 +33,7 @@ const delegatedProps = computed(() => {
   >
     <ProgressIndicator
       class="h-full w-full flex-1 bg-primary transition-all"
-      :style="`transform: translateX(-${100 - (props.modelValue ?? 0)}%);`"
+      :style="`transform: translateX(-${100 - (props.modelValue ?? 0) * 100 / (props.max ?? 100)}%);`"
     />
   </ProgressRoot>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/progress/Progress.vue
+++ b/apps/www/src/lib/registry/new-york/ui/progress/Progress.vue
@@ -11,6 +11,7 @@ const props = withDefaults(
   defineProps<ProgressRootProps & { class?: HTMLAttributes['class'] }>(),
   {
     modelValue: 0,
+    max: 100
   },
 )
 
@@ -33,7 +34,7 @@ const delegatedProps = computed(() => {
   >
     <ProgressIndicator
       class="h-full w-full flex-1 bg-primary transition-all"
-      :style="`transform: translateX(-${100 - (props.modelValue ?? 0) * 100 / (props.max ?? 100)}%);`"
+      :style="`transform: translateX(-${100 - (props.modelValue ?? 0) * 100 / props.max}%);`"
     />
   </ProgressRoot>
 </template>

--- a/apps/www/src/lib/registry/new-york/ui/progress/Progress.vue
+++ b/apps/www/src/lib/registry/new-york/ui/progress/Progress.vue
@@ -33,7 +33,7 @@ const delegatedProps = computed(() => {
   >
     <ProgressIndicator
       class="h-full w-full flex-1 bg-primary transition-all"
-      :style="`transform: translateX(-${100 - (props.modelValue ?? 0)}%);`"
+      :style="`transform: translateX(-${100 - (props.modelValue ?? 0) * 100 / (props.max ?? 100)}%);`"
     />
   </ProgressRoot>
 </template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#899

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The Progress component has support for a max property, but the shadcn-vue version uses a fixed max value of 100 while rendering. The max property should be taken into consideration and 100 should be the default when the optional max property is not there.
Resolves #899


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
