### PR TITLE
fix: temporarily downgrade vue-metamorph to 3.2.0 due to cli TSInterfaceHeritage error

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,7 @@
     "radix-vue": "catalog:",
     "semver": "^7.6.3",
     "tsconfig-paths": "^4.2.0",
-    "vue-metamorph": "^3.2.0",
+    "vue-metamorph": "3.2.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,7 +310,7 @@ importers:
         specifier: '*'
         version: 2.1.3(@types/node@22.7.7)(@vitest/ui@2.1.3)(stylus@0.57.0)(terser@5.36.0)
       vue-metamorph:
-        specifier: ^3.2.0
+        specifier: 3.2.0
         version: 3.2.0(eslint@9.13.0(jiti@2.3.3))
       zod:
         specifier: ^3.23.8


### PR DESCRIPTION

<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

- https://github.com/unovue/shadcn-vue/issues/905

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When using npx shadcn-vue@latest, the vue-metamorph version is not locked, causing the problematic 3.2.2 version to be executed. This leads to the error: did not recognize object of type "TSInterfaceHeritage".

To address this, the vue-metamorph version is temporarily locked to 3.2.0, ensuring that components can be downloaded and used without issues.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
