### PR TITLE
fix: prevent shrinking theme customizer circles

### DIFF
--- a/apps/www/.vitepress/theme/components/ThemeCustomizer.vue
+++ b/apps/www/.vitepress/theme/components/ThemeCustomizer.vue
@@ -43,7 +43,7 @@ const { isDark } = useData()
           @click="setTheme(color)"
         >
           <span
-            class="h-5 w-5 rounded-full flex items-center justify-center flex-shrink-0"
+            class="h-5 w-5 rounded-full flex items-center justify-center shrink-0"
             :style="{ backgroundColor: colors[color][7].rgb }"
           >
             <RadixIconsCheck

--- a/apps/www/.vitepress/theme/components/ThemeCustomizer.vue
+++ b/apps/www/.vitepress/theme/components/ThemeCustomizer.vue
@@ -43,7 +43,7 @@ const { isDark } = useData()
           @click="setTheme(color)"
         >
           <span
-            class="h-5 w-5 rounded-full flex items-center justify-center"
+            class="h-5 w-5 rounded-full flex items-center justify-center flex-shrink-0"
             :style="{ backgroundColor: colors[color][7].rgb }"
           >
             <RadixIconsCheck


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
- Added `shrink-0` to color circle elements in ThemeCustomizer to maintain consistent dimensions
<!-- Why is this change required? What problem does it solve? -->
- Some of the circles were being shrinked when they selected or in their default state
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots
#### before
![theme-customizer-before](https://github.com/user-attachments/assets/7787c579-8a29-40a7-8a4c-8a9475b280c2)

#### after
![theme-customizer-after](https://github.com/user-attachments/assets/c724cc33-aacf-4cf2-b86d-c723413666ab)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
