### PR TITLE
feat: add support for File type in Input component

### DIFF
--- a/apps/www/src/lib/registry/default/ui/input/Input.vue
+++ b/apps/www/src/lib/registry/default/ui/input/Input.vue
@@ -4,8 +4,8 @@ import { cn } from '@/lib/utils'
 import { useVModel } from '@vueuse/core'
 
 const props = defineProps<{
-  defaultValue?: string | number
-  modelValue?: string | number
+  defaultValue?: string | number | File
+  modelValue?: string | number | File
   class?: HTMLAttributes['class']
 }>()
 


### PR DESCRIPTION
### 🔗 Linked issue

No open issue exists, but this change improves the handling of file inputs.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Input component now supports the File type for both modelValue and defaultValue. This enhancement allows the component to work seamlessly with file inputs without causing type errors or warnings.

**What has changed:**
- Added File as a valid type for the modelValue and defaultValue props.
- This change is fully backward-compatible and does not affect existing functionality.

**Why this change is needed:**
Currently, when using the Input component with type="file", Vue emits a warning for an invalid prop type. This update enables the component to natively handle the File type, improving flexibility and usability.

<img width="975" alt="image" src="https://github.com/user-attachments/assets/6e0aa54b-11eb-454a-95dc-a65371bccaed">

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
