### PR TITLE
docs: fix broken link in footer

### DIFF
--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -209,7 +209,7 @@ watch(() => $route.path, (n) => {
             <span class="inline-block ml-2">
               Ported to Vue by
               <a
-                href="https://www.radix-vue.com/"
+                href="https://github.com/unovue"
                 target="_blank"
                 class="underline underline-offset-4 font-bold decoration-foreground"
               >

--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -209,7 +209,7 @@ watch(() => $route.path, (n) => {
             <span class="inline-block ml-2">
               Ported to Vue by
               <a
-                href="https://github.com/radix-vue"
+                href="https://www.radix-vue.com/"
                 target="_blank"
                 class="underline underline-offset-4 font-bold decoration-foreground"
               >


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
 
Do I really need one?
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fix a broken link found in the footer.
Which one should I use as a replacement ?
- https://www.radix-vue.com
- https://github.com/unovue/radix-vue

### 📸 Screenshots (if appropriate)

This links point to a 404:

![image](https://github.com/user-attachments/assets/6db844ce-47e2-420d-9385-277e7a7529f0)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
