### PR TITLE
fix: ts types for `headingValue` in `CalendarHeading` and `RangeCalendarHeading  components

### DIFF
--- a/apps/www/src/lib/registry/default/ui/calendar/CalendarHeading.vue
+++ b/apps/www/src/lib/registry/default/ui/calendar/CalendarHeading.vue
@@ -14,7 +14,7 @@ const delegatedProps = computed(() => {
 const forwardedProps = useForwardProps(delegatedProps)
   
 const slots = defineSlots<{
-  default(props: { headingValue: string }): string
+  default(props: { headingValue: string }): any
 }>()
 </script>
 

--- a/apps/www/src/lib/registry/default/ui/calendar/CalendarHeading.vue
+++ b/apps/www/src/lib/registry/default/ui/calendar/CalendarHeading.vue
@@ -12,6 +12,10 @@ const delegatedProps = computed(() => {
 })
 
 const forwardedProps = useForwardProps(delegatedProps)
+  
+const slots = defineSlots<{
+  default(props: { headingValue: string }): string
+}>()
 </script>
 
 <template>

--- a/apps/www/src/lib/registry/default/ui/range-calendar/RangeCalendarHeading.vue
+++ b/apps/www/src/lib/registry/default/ui/range-calendar/RangeCalendarHeading.vue
@@ -14,7 +14,7 @@ const delegatedProps = computed(() => {
 const forwardedProps = useForwardProps(delegatedProps)
   
 const slots = defineSlots<{
-  default(props: { headingValue: string }): string
+  default(props: { headingValue: string }): any
 }>()
 </script>
 

--- a/apps/www/src/lib/registry/default/ui/range-calendar/RangeCalendarHeading.vue
+++ b/apps/www/src/lib/registry/default/ui/range-calendar/RangeCalendarHeading.vue
@@ -12,6 +12,10 @@ const delegatedProps = computed(() => {
 })
 
 const forwardedProps = useForwardProps(delegatedProps)
+  
+const slots = defineSlots<{
+  default(props: { headingValue: string }): string
+}>()
 </script>
 
 <template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Resolves #638 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This pull request addresses a TypeScript typing issue in the `CalendarHeading` component where `headingValue` was implicitly typed as `any`. The solution ensures explicit typing of the slot props, preventing further TypeScript errors and improving type safety.

- Refactored `v-slot` usage to explicitly declare the type of `headingValue` as `string`.
- Added proper TypeScript annotations for slot props, ensuring compatibility with both Vue 3's template syntax and TypeScript's inference.

Btw, I'm using Inertia.js with vite 6.0 with strict types

### 📸 Screenshots (if appropriate)
<img width="755" alt="image" src="https://github.com/user-attachments/assets/74573636-eefc-449b-9314-0d9eb3f89824" />

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.