### PR TITLE
fix(module): allow using without recommended modules

### DIFF
--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -49,6 +49,8 @@ export default defineNuxtConfig({
 })
 ```
 
+Note that if you prefer not to install the TailwindCSS module, please set `suppressMissingModuleWarning` to `true` in module options.
+
 ### Add `Nuxt` module
 
 <br>
@@ -196,7 +198,12 @@ export default defineNuxtConfig({
      * Directory that the component lives in.
      * @default "./components/ui"
      */
-    componentDir: './components/ui'
+    componentDir: './components/ui',
+    /**
+     * Suppress warning about missing modules
+     * @default false
+     */
+    suppressMissingModuleWarning: boolean
   }
 })
 ```

--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -16,6 +16,11 @@ export interface ModuleOptions {
    * @default "./components/ui"
    */
   componentDir?: string
+  /**
+   * Suppress warning about missing modules
+   * @default false
+   */
+  suppressMissingModuleWarning?: boolean
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -26,8 +31,9 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     prefix: '',
     componentDir: './components/ui',
+    suppressMissingModuleWarning: false,
   },
-  async setup({ prefix, componentDir }, nuxt) {
+  async setup({ prefix, componentDir, suppressMissingModuleWarning }, nuxt) {
     const COMPONENT_DIR_PATH = componentDir!
     const ROOT_DIR_PATH = nuxt.options.rootDir
     const UTILS_ALIAS = '@/lib/utils' // Use the same path from the cli for backward compatibility
@@ -59,11 +65,15 @@ export default defineNuxtModule<ModuleOptions>({
       })
     })
 
-    // Install the `@nuxtjs/tailwindcss` module.
-    await installModule('@nuxtjs/tailwindcss')
-
-    // Installs the `@nuxtjs/color-mode` module.
-    await installModule('@nuxtjs/color-mode')
+    const modulesToInstall = ['@nuxtjs/tailwindcss', '@nuxtjs/color-mode']
+    for (const module of modulesToInstall) {
+      if (nuxt.options._installedModules.some(m => m.meta.name === module)) {
+        await installModule(module)
+      }
+      else if (!suppressMissingModuleWarning) {
+        logger.warn(`[shadcn-nuxt] \`${module}\` is not installed. To suppress this warning, set \`suppressMissingModuleWarning\` to \`true\` in module options.`)
+      }
+    }
 
     // Manually scan `componentsDir` for components and register them for auto imports
     try {

--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -67,7 +67,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     const modulesToInstall = ['@nuxtjs/tailwindcss', '@nuxtjs/color-mode']
     for (const module of modulesToInstall) {
-      if (nuxt.options._installedModules.some(m => m.meta.name === module)) {
+      if (await findPath(await resolvePath(module))) {
         await installModule(module)
       }
       else if (!suppressMissingModuleWarning) {


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves #979, Resolves #883. This PR does two things:
1. If the two modules (`@nuxtjs/tailwindcss` or `@nuxtjs/color-mode`) are not installed, then we will not call `installModule()`, instead we'll give a warning about this.
2. Added a config option (`suppressMissingModuleWarning`) to suppress the above warning.

### 📸 Screenshots (if appropriate)

N/A

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
