### PR TITLE
docs: trim breadcrumb example whitespace

### DIFF
--- a/apps/www/src/lib/registry/default/example/BreadcrumbResponsive.vue
+++ b/apps/www/src/lib/registry/default/example/BreadcrumbResponsive.vue
@@ -104,7 +104,7 @@ const remainingItems = computed(() => items.value.slice(-itemsToDisplay + 1))
         </BreadcrumbItem>
         <BreadcrumbSeparator />
       </template>
-      <BreadcrumbItem v-for=" item of remainingItems" :key="item.label">
+      <BreadcrumbItem v-for="item of remainingItems" :key="item.label">
         <template v-if="item.href">
           <BreadcrumbLink
             as-child

--- a/apps/www/src/lib/registry/new-york/example/BreadcrumbResponsive.vue
+++ b/apps/www/src/lib/registry/new-york/example/BreadcrumbResponsive.vue
@@ -104,7 +104,7 @@ const remainingItems = computed(() => items.value.slice(-itemsToDisplay + 1))
         </BreadcrumbItem>
         <BreadcrumbSeparator />
       </template>
-      <BreadcrumbItem v-for=" item of remainingItems" :key="item.label">
+      <BreadcrumbItem v-for="item of remainingItems" :key="item.label">
         <template v-if="item.href">
           <BreadcrumbLink
             as-child


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A very small PR that remove whitespace in breadcrumb examples.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
