### PR TITLE
Update vite docs install for Vite v6 + Tailwind v4

### DIFF
--- a/apps/www/src/content/docs/installation/vite.md
+++ b/apps/www/src/content/docs/installation/vite.md
@@ -30,10 +30,8 @@ Install `tailwindcss` and its peer dependencies, then generate your `tailwind.co
 <TabsMarkdown>
   <TabMarkdown title="vite.config">
 
-  Vite already has [`postcss`](https://github.com/vitejs/vite/blob/main/packages/vite/package.json#89) dependency so you don't have to install it again in your package.json
-
   ```bash
-  npm install -D tailwindcss autoprefixer
+  npm install -D tailwindcss @tailwindcss/vite
   ```
 
   <Callout>
@@ -46,18 +44,12 @@ Install `tailwindcss` and its peer dependencies, then generate your `tailwind.co
 
 ```typescript {2,3,8-12}
 import vue from '@vitejs/plugin-vue'
-import autoprefixer from 'autoprefixer'
-import tailwind from 'tailwindcss'
+import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 
 // https://vite.dev/config/
 export default defineConfig({
-  css: {
-    postcss: {
-      plugins: [tailwind(), autoprefixer()],
-    },
-  },
-  plugins: [vue()],
+  plugins: [vue(), tailwindcss()],
 })
 ```
 
@@ -118,18 +110,12 @@ npm i -D @types/node
 ```typescript {1,15-19}
 import { fileURLToPath, URL } from 'node:url'
 import vue from '@vitejs/plugin-vue'
-import autoprefixer from 'autoprefixer'
-import tailwind from 'tailwindcss'
+import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 
 // https://vite.dev/config/
 export default defineConfig({
-  css: {
-    postcss: {
-      plugins: [tailwind(), autoprefixer()],
-    },
-  },
-  plugins: [vue()],
+  plugins: [vue(), tailwindcss()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))

--- a/apps/www/src/content/docs/installation/vite.md
+++ b/apps/www/src/content/docs/installation/vite.md
@@ -58,7 +58,7 @@ export default defineConfig({
   <TabMarkdown title="postcss.config.js">
 
   ```bash
-  npm install -D tailwindcss autoprefixer postcss
+  npm install -D @tailwindcss/postcss
   ```
 
 #### `postcss.config.js`
@@ -66,8 +66,7 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      tailwindcss: {},
-      autoprefixer: {},
+      "@tailwindcss/postcss"
     },
   }
   ```


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Installing using VITE v6.0.11, it appears that postcss is no longer included in the vite installation

Also breaking changes related to Tailwind v4

> Error: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin. The PostCSS plugin has mov ed to a separate package, so to continue using Tailwind CSS with PostCSS you'll need to install `@tailwindcss/po stcss` and update your PostCSS configuration.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
