### PR TITLE
docs: Change href to link to the example instead of a non existing page

### DIFF
--- a/apps/www/src/examples/authentication/Example.vue
+++ b/apps/www/src/examples/authentication/Example.vue
@@ -70,14 +70,14 @@ import UserAuthForm from './components/UserAuthForm.vue'
         <p class="px-8 text-center text-sm text-muted-foreground">
           By clicking continue, you agree to our
           <a
-            href="/terms"
+            href="/examples/authentication"
             class="underline underline-offset-4 hover:text-primary"
           >
             Terms of Service
           </a>
           and
           <a
-            href="/privacy"
+            href="/examples/authentication"
             class="underline underline-offset-4 hover:text-primary"
           >
             Privacy Policy


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Change href to link to the example instead of a non existing page. This is similar to how the "Login" button in the authentication example works.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
