### PR TITLE
fix: calendar heading slots typing

### DIFF
--- a/apps/www/src/lib/registry/default/ui/calendar/CalendarHeading.vue
+++ b/apps/www/src/lib/registry/default/ui/calendar/CalendarHeading.vue
@@ -5,6 +5,10 @@ import { computed, type HTMLAttributes } from 'vue'
 
 const props = defineProps<CalendarHeadingProps & { class?: HTMLAttributes['class'] }>()
 
+defineSlots<{
+  default: (props: { headingValue: string }) => any
+}>()
+
 const delegatedProps = computed(() => {
   const { class: _, ...delegated } = props
 

--- a/apps/www/src/lib/registry/default/ui/range-calendar/RangeCalendarHeading.vue
+++ b/apps/www/src/lib/registry/default/ui/range-calendar/RangeCalendarHeading.vue
@@ -5,6 +5,10 @@ import { computed, type HTMLAttributes } from 'vue'
 
 const props = defineProps<RangeCalendarHeadingProps & { class?: HTMLAttributes['class'] }>()
 
+defineSlots<{
+  default: (props: { headingValue: string }) => any
+}>()
+
 const delegatedProps = computed(() => {
   const { class: _, ...delegated } = props
 

--- a/apps/www/src/lib/registry/new-york/ui/calendar/CalendarHeading.vue
+++ b/apps/www/src/lib/registry/new-york/ui/calendar/CalendarHeading.vue
@@ -5,6 +5,10 @@ import { computed, type HTMLAttributes } from 'vue'
 
 const props = defineProps<CalendarHeadingProps & { class?: HTMLAttributes['class'] }>()
 
+defineSlots<{
+  default: (props: { headingValue: string }) => any
+}>()
+
 const delegatedProps = computed(() => {
   const { class: _, ...delegated } = props
 

--- a/apps/www/src/lib/registry/new-york/ui/range-calendar/RangeCalendarHeading.vue
+++ b/apps/www/src/lib/registry/new-york/ui/range-calendar/RangeCalendarHeading.vue
@@ -5,6 +5,10 @@ import { computed, type HTMLAttributes } from 'vue'
 
 const props = defineProps<RangeCalendarHeadingProps & { class?: HTMLAttributes['class'] }>()
 
+defineSlots<{
+  default: (props: { headingValue: string }) => any
+}>()
+
 const delegatedProps = computed(() => {
   const { class: _, ...delegated } = props
 


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Fixes #1020 properly.

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

type the default slot in `CalendarHeading` and `RangeCalendarHeading`

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
