### PR TITLE
fix(tagsinputformdemo): fix issue where the demo form is not reactive

### DIFF
--- a/apps/www/src/registry/default/example/TagsInputFormDemo.vue
+++ b/apps/www/src/registry/default/example/TagsInputFormDemo.vue
@@ -36,12 +36,15 @@ const onSubmit = handleSubmit((values) => {
 
 <template>
   <form class="w-2/3 space-y-6" @submit="onSubmit">
-    <FormField v-slot="{ value }" name="fruits">
+    <FormField v-slot="{ componentField }" name="fruits">
       <FormItem>
         <FormLabel>Fruits</FormLabel>
         <FormControl>
-          <TagsInput :model-value="value">
-            <TagsInputItem v-for="item in value" :key="item" :value="item">
+          <TagsInput
+            :model-value="componentField.modelValue"
+            @update:model-value="componentField['onUpdate:modelValue']"
+          >
+            <TagsInputItem v-for="item in componentField.modelValue" :key="item" :value="item">
               <TagsInputItemText />
               <TagsInputItemDelete />
             </TagsInputItem>

--- a/apps/www/src/registry/new-york/example/TagsInputFormDemo.vue
+++ b/apps/www/src/registry/new-york/example/TagsInputFormDemo.vue
@@ -36,12 +36,15 @@ const onSubmit = handleSubmit((values) => {
 
 <template>
   <form class="w-2/3 space-y-6" @submit="onSubmit">
-    <FormField v-slot="{ value }" name="fruits">
+    <FormField v-slot="{ componentField }" name="fruits">
       <FormItem>
         <FormLabel>Fruits</FormLabel>
         <FormControl>
-          <TagsInput :model-value="value">
-            <TagsInputItem v-for="item in value" :key="item" :value="item">
+          <TagsInput
+            :model-value="componentField.modelValue"
+            @update:model-value="componentField['onUpdate:modelValue']"
+          >
+            <TagsInputItem v-for="item in componentField.modelValue" :key="item" :value="item">
               <TagsInputItemText />
               <TagsInputItemDelete />
             </TagsInputItem>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#1071

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I had to change the v-slot to use the `componentField` instead of `value`

Resolve #1071 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
