### PR TITLE
fix: use correct icon for pagination last component

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/pagination/PaginationLast.vue
+++ b/apps/v4/registry/new-york-v4/ui/pagination/PaginationLast.vue
@@ -4,7 +4,7 @@ import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'
 import { buttonVariants, type ButtonVariants } from '@/registry/new-york-v4/ui/button'
 import { reactiveOmit } from '@vueuse/core'
-import { ChevronLeftIcon } from 'lucide-vue-next'
+import { ChevronRightIcon } from 'lucide-vue-next'
 import { PaginationLast, useForwardProps } from 'reka-ui'
 
 const props = withDefaults(defineProps<PaginationLastProps & {
@@ -26,7 +26,7 @@ const forwarded = useForwardProps(delegatedProps)
   >
     <slot>
       <span class="hidden sm:block">Last</span>
-      <ChevronLeftIcon />
+      <ChevronRightIcon />
     </slot>
   </PaginationLast>
 </template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#1156 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the wrong icon (chevron left) is rendered in the v4 version of the `PaginationLast` component. This PR fixes that by replacing chevron left for chevron right.

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
