### PR TITLE
docs: updated pagination component documentation

### DIFF
--- a/apps/www/src/content/docs/components/pagination.md
+++ b/apps/www/src/content/docs/components/pagination.md
@@ -26,31 +26,31 @@ import {
   PaginationEllipsis,
   PaginationFirst,
   PaginationLast,
-  PaginationList,
-  PaginationListItem,
+  PaginationContent,
+  PaginationItem,
   PaginationNext,
-  PaginationPrev,
+  PaginationPrevious,
 } from '@/components/ui/pagination'
 </script>
 
 <template>
   <Pagination v-slot="{ page }" :items-per-page="10" :total="100" :sibling-count="1" show-edges :default-page="2">
-    <PaginationList v-slot="{ items }" class="flex items-center gap-1">
+    <PaginationContent v-slot="{ items }" class="flex items-center gap-1">
       <PaginationFirst />
-      <PaginationPrev />
+      <PaginationPrevious />
 
       <template v-for="(item, index) in items">
-        <PaginationListItem v-if="item.type === 'page'" :key="index" :value="item.value" as-child>
+        <PaginationItem v-if="item.type === 'page'" :key="index" :value="item.value" as-child>
           <Button class="w-10 h-10 p-0" :variant="item.value === page ? 'default' : 'outline'">
             {{ item.value }}
           </Button>
-        </PaginationListItem>
+        </PaginationItem>
         <PaginationEllipsis v-else :key="item.type" :index="index" />
       </template>
 
       <PaginationNext />
       <PaginationLast />
-    </PaginationList>
+    </PaginationContent>
   </Pagination>
 </template>
 ```


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#1179 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, as described in the issue. The components names are different than the ones used in the documentation. We can either rename the components or update the documentation. 

This PR updates the documentation to match the new names.
1. PaginationList in docs is PaginationContent in code
2. PaginationListItem in docs is PaginationItem in code
3. PaginationPrev in docs is PaginationPrevious in code
This should resolve issue #1179 

Link to [documentation pagination component page](https://www.shadcn-vue.com/docs/components/pagination.html#usage)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
