### PR TITLE
fix display of icon in callout

### DIFF
--- a/apps/www/.vitepress/theme/components/Callout.vue
+++ b/apps/www/.vitepress/theme/components/Callout.vue
@@ -18,7 +18,7 @@ const props = defineProps<CalloutProps>()
 
 <template>
   <Alert class="not-docs" :class="cn('my-6 bg-muted/50', props.class)">
-    <span v-if="icon" classs="mr-4 text-2xl">{icon}</span>
+    <span v-if="icon" classs="mr-4 text-2xl">{{ icon }}</span>
     <AlertTitle v-if="title">
       {{ title }}
     </AlertTitle>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#1181 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

fix mustache syntax in `Callout.vue` to be shown content of `icon` in props.

### 📸 Screenshots (if appropriate)

fixed:
![image](https://github.com/user-attachments/assets/cc441ab2-8947-4404-b57a-e33517748902)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
