### PR TITLE
fix(callout,docs): correct class typo

### DIFF
--- a/apps/www/.vitepress/theme/components/Callout.vue
+++ b/apps/www/.vitepress/theme/components/Callout.vue
@@ -18,7 +18,7 @@ const props = defineProps<CalloutProps>()
 
 <template>
   <Alert class="not-docs" :class="cn('my-6 bg-muted/50', props.class)">
-    <span v-if="icon" classs="mr-4 text-2xl">{{ icon }}</span>
+    <span v-if="icon" class="mr-4 text-2xl">{{ icon }}</span>
     <AlertTitle v-if="title">
       {{ title }}
     </AlertTitle>

--- a/apps/www/src/content/docs/components/sidebar.md
+++ b/apps/www/src/content/docs/components/sidebar.md
@@ -761,7 +761,7 @@ This button works independently of the `SidebarMenuButton` i.e. you can have the
       </a>
     </SidebarMenuButton>
     <SidebarMenuAction>
-      <Plus /> <span classs="sr-only">Add Project</span>
+      <Plus /> <span class="sr-only">Add Project</span>
     </SidebarMenuAction>
   </SidebarMenuItem>
 </template>
@@ -849,7 +849,7 @@ A collapsible sidebar menu.
 ```vue:line-numbers
 <template>
   <SidebarMenu>
-    <Collapsible defaultOpen classs="group/collapsible">
+    <Collapsible defaultOpen class="group/collapsible">
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
           <SidebarMenuButton />


### PR DESCRIPTION
###  Description  
Fixed `classs=""` → `class="` in:  
- **Component**: 
`components/Callout.vue`  
- **Documentation**: `docs/components/sidebar.md`  

- [ ] I have linked an issue or discussion.
- [x ] I have updated the documentation accordingly.
