### PR TITLE
Fix Naming Issue in Pagination Component Documentation

### DIFF
--- a/apps/www/src/content/docs/components/pagination.md
+++ b/apps/www/src/content/docs/components/pagination.md
@@ -26,8 +26,8 @@ import {
   PaginationEllipsis,
   PaginationFirst,
   PaginationLast,
-  PaginationList,
-  PaginationListItem,
+  PaginationContent,
+  PaginationItem,
   PaginationNext,
   PaginationPrev,
 } from '@/components/ui/pagination'
@@ -35,22 +35,22 @@ import {
 
 <template>
   <Pagination v-slot="{ page }" :items-per-page="10" :total="100" :sibling-count="1" show-edges :default-page="2">
-    <PaginationList v-slot="{ items }" class="flex items-center gap-1">
+    <PaginationContent v-slot="{ items }" class="flex items-center gap-1">
       <PaginationFirst />
       <PaginationPrev />
 
       <template v-for="(item, index) in items">
-        <PaginationListItem v-if="item.type === 'page'" :key="index" :value="item.value" as-child>
+        <PaginationItem v-if="item.type === 'page'" :key="index" :value="item.value" as-child>
           <Button class="w-10 h-10 p-0" :variant="item.value === page ? 'default' : 'outline'">
             {{ item.value }}
           </Button>
-        </PaginationListItem>
+        </PaginationItem>
         <PaginationEllipsis v-else :key="item.type" :index="index" />
       </template>
 
       <PaginationNext />
       <PaginationLast />
-    </PaginationList>
+    </PaginationContent>
   </Pagination>
 </template>
 ```


### PR DESCRIPTION
Description:

This pull request updates the documentation for the Pagination component to address a naming issue that confused users when implementing this component in projects. Specifically:

PaginationList has been renamed to PaginationContent. PaginationListItem has been renamed to PaginationItem. These changes ensure that the component names in the documentation align correctly with their actual implementation. Previously, attempting to copy and use the examples from the documentation would result in errors due to the mismatched names. This fix resolves the issue and improves the developer experience by providing accurate examples.

Why this is important: This inconsistency caused unnecessary debugging and confusion for developers using the Pagination component. With this update, the documentation reflects the correct naming, making it easier to integrate the component seamlessly.

Please let me know if you need any more adjustments!

![Screenshot 2025-04-23 at 18 14 48](https://github.com/user-attachments/assets/b79e9f44-819f-463f-a0f8-216d0c1b8c35)

