### PR TITLE
fix(MainLayout): prevent hydration mismatch by checking isMounted before rendering dark/light mode theme toggle button

### DIFF
--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -27,10 +27,13 @@ import ThemePopover from '../components/ThemePopover.vue'
 import { docsConfig } from '../config/docs'
 
 const { radius, theme } = useConfigStore()
+const isMounted = ref(false)
 // Whenever the component is mounted, update the document class list
 onMounted(() => {
   document.documentElement.style.setProperty('--radius', `${radius.value}rem`)
   document.documentElement.classList.add(`theme-${theme.value}`)
+
+  isMounted.value = true
 })
 
 const { frontmatter, isDark } = useData()
@@ -132,6 +135,7 @@ function handleSelectLink(item: NavItem) {
                     </Button>
 
                     <Button
+                      v-if="isMounted"
                       class="w-8 h-8"
                       aria-label="Toggle dark mode"
                       :variant="'ghost'"

--- a/apps/www/.vitepress/theme/layout/MainLayout.vue
+++ b/apps/www/.vitepress/theme/layout/MainLayout.vue
@@ -27,13 +27,10 @@ import ThemePopover from '../components/ThemePopover.vue'
 import { docsConfig } from '../config/docs'
 
 const { radius, theme } = useConfigStore()
-const isMounted = ref(false)
 // Whenever the component is mounted, update the document class list
 onMounted(() => {
   document.documentElement.style.setProperty('--radius', `${radius.value}rem`)
   document.documentElement.classList.add(`theme-${theme.value}`)
-
-  isMounted.value = true
 })
 
 const { frontmatter, isDark } = useData()
@@ -135,17 +132,18 @@ function handleSelectLink(item: NavItem) {
                     </Button>
 
                     <Button
-                      v-if="isMounted"
                       class="w-8 h-8"
                       aria-label="Toggle dark mode"
                       :variant="'ghost'"
                       :size="'icon'"
                       @click="toggleDark()"
                     >
-                      <component
-                        :is="isDark ? SunIcon : MoonIcon"
-                        class="w-4 h-4 text-foreground"
-                      />
+                      <ClientOnly>
+                        <component
+                          :is="isDark ? SunIcon : MoonIcon"
+                          class="w-4 h-4 text-foreground"
+                        />
+                      </ClientOnly>
                     </Button>
                   </nav>
                 </div>


### PR DESCRIPTION
### 🔗 Linked issue

#1208 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes a hydration mismatch issue that occurs on the [shadcn-vue main page](https://www.shadcn-vue.com/) when switching theme modes.

### 🐛 Problem

When visiting the site with **dark mode enabled by default**, clicking the **theme toggle** button to switch to light mode causes the **icon on the button to disappear**. This leaves the toggle visually invisible and logs the following error in the browser console:
`Hydration completed but contains mismatches.`
`NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.`

This issue is caused by a mismatch between the DOM rendered by the server (SSR) and what Vue renders on the client during hydration.

The `isDark` value is derived from client-only state (like `localStorage` or the user's system preference), which isn't available during SSR. This causes the server to render a different DOM tree than what the client renders once it's mounted, especially for components that rely on `isDark` such as the theme toggle icon.

---

### ✅ Fix

This PR wraps the theme toggle `<Button>` in a `v-if="isMounted"` check to ensure it's only rendered **after the component is mounted on the client**. This avoids any hydration mismatch by skipping this client-only logic during SSR.

```vue
<Button v-if="isMounted" ...>
  <component :is="isDark ? SunIcon : MoonIcon" />
</Button>
```

### 📸 Screenshots (if appropriate)

Before:
![before](https://github.com/user-attachments/assets/d5a0ffd1-cb1e-4c2d-aaf9-f1b8bd944dba)

After:
![after](https://github.com/user-attachments/assets/8828dce6-7f43-4029-9187-e4920d8c2ea5)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

---

I'm happy to adjust anything if needed — open to any feedback or suggestions! 🙌