### PR TITLE
Update PinInputGroup.vue

### DIFF
--- a/apps/www/src/registry/default/ui/pin-input/PinInputGroup.vue
+++ b/apps/www/src/registry/default/ui/pin-input/PinInputGroup.vue
@@ -14,5 +14,5 @@ const forwardedProps = useForwardProps(delegatedProps)
 <template>
   <Primitive v-bind="forwardedProps" :class="cn('flex items-center', props.class)">
     <slot />
-  </primitive>
+  </Primitive>
 </template>


### PR DESCRIPTION
Fix typo: corrected the tag name `(primitive → Primitive)` in the template.

