### PR TITLE
fix(Toggle, ToggleGroup): forward scoped slot

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/toggle-group/ToggleGroup.vue
+++ b/apps/v4/registry/new-york-v4/ui/toggle-group/ToggleGroup.vue
@@ -26,12 +26,13 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 
 <template>
   <ToggleGroupRoot
+    v-slot="slotProps"
     data-slot="toggle-group"
     :data-size="size"
     :data-variant="variant"
     v-bind="forwarded"
     :class="cn('group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs', props.class)"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </ToggleGroupRoot>
 </template>

--- a/apps/v4/registry/new-york-v4/ui/toggle-group/ToggleGroupItem.vue
+++ b/apps/v4/registry/new-york-v4/ui/toggle-group/ToggleGroupItem.vue
@@ -22,6 +22,7 @@ const forwardedProps = useForwardProps(delegatedProps)
 
 <template>
   <ToggleGroupItem
+    v-slot="slotProps"
     data-slot="toggle-group-item"
     :data-variant="context?.variant || variant"
     :data-size="context?.size || size"
@@ -34,6 +35,6 @@ const forwardedProps = useForwardProps(delegatedProps)
       'min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l',
       props.class)"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </ToggleGroupItem>
 </template>

--- a/apps/v4/registry/new-york-v4/ui/toggle/Toggle.vue
+++ b/apps/v4/registry/new-york-v4/ui/toggle/Toggle.vue
@@ -23,10 +23,11 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 
 <template>
   <Toggle
+    v-slot="slotProps"
     data-slot="toggle"
     v-bind="forwarded"
     :class="cn(toggleVariants({ variant, size }), props.class)"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </Toggle>
 </template>

--- a/apps/www/src/registry/default/ui/toggle-group/ToggleGroup.vue
+++ b/apps/www/src/registry/default/ui/toggle-group/ToggleGroup.vue
@@ -28,7 +28,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>
 
 <template>
-  <ToggleGroupRoot v-bind="forwarded" :class="cn('flex items-center justify-center gap-1', props.class)">
-    <slot />
+  <ToggleGroupRoot v-slot="slotProps" v-bind="forwarded" :class="cn('flex items-center justify-center gap-1', props.class)">
+    <slot v-bind="slotProps" />
   </ToggleGroupRoot>
 </template>

--- a/apps/www/src/registry/default/ui/toggle-group/ToggleGroupItem.vue
+++ b/apps/www/src/registry/default/ui/toggle-group/ToggleGroupItem.vue
@@ -25,11 +25,12 @@ const forwardedProps = useForwardProps(delegatedProps)
 
 <template>
   <ToggleGroupItem
+    v-slot="slotProps"
     v-bind="forwardedProps" :class="cn(toggleVariants({
       variant: context?.variant || variant,
       size: context?.size || size,
     }), props.class)"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </ToggleGroupItem>
 </template>

--- a/apps/www/src/registry/default/ui/toggle/Toggle.vue
+++ b/apps/www/src/registry/default/ui/toggle/Toggle.vue
@@ -27,9 +27,10 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 
 <template>
   <Toggle
+    v-slot="slotProps"
     v-bind="forwarded"
     :class="cn(toggleVariants({ variant, size }), props.class)"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </Toggle>
 </template>

--- a/apps/www/src/registry/new-york/ui/toggle-group/ToggleGroup.vue
+++ b/apps/www/src/registry/new-york/ui/toggle-group/ToggleGroup.vue
@@ -28,7 +28,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>
 
 <template>
-  <ToggleGroupRoot v-bind="forwarded" :class="cn('flex items-center justify-center gap-1', props.class)">
-    <slot />
+  <ToggleGroupRoot v-slot="slotProps" v-bind="forwarded" :class="cn('flex items-center justify-center gap-1', props.class)">
+    <slot v-bind="slotProps" />
   </ToggleGroupRoot>
 </template>

--- a/apps/www/src/registry/new-york/ui/toggle-group/ToggleGroupItem.vue
+++ b/apps/www/src/registry/new-york/ui/toggle-group/ToggleGroupItem.vue
@@ -25,11 +25,12 @@ const forwardedProps = useForwardProps(delegatedProps)
 
 <template>
   <ToggleGroupItem
+    v-slot="slotProps"
     v-bind="forwardedProps" :class="cn(toggleVariants({
       variant: context?.variant || variant,
       size: context?.size || size,
     }), props.class)"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </ToggleGroupItem>
 </template>

--- a/apps/www/src/registry/new-york/ui/toggle/Toggle.vue
+++ b/apps/www/src/registry/new-york/ui/toggle/Toggle.vue
@@ -27,9 +27,10 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 
 <template>
   <Toggle
+    v-slot="slotProps"
     v-bind="forwarded"
     :class="cn(toggleVariants({ variant, size }), props.class)"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </Toggle>
 </template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR updates the wrapper `Toggle` and `ToggleGroup` component to properly forward scoped slot props (e.g. state, modelValue, pressed, disabled) from the underlying reka-ui components.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
