### PR TITLE
fix(Stepper): bind slot props at indicator in default slot

### DIFF
--- a/apps/v4/components/StepperDemo.vue
+++ b/apps/v4/components/StepperDemo.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { BookUser, CreditCard, Truck } from 'lucide-vue-next'
+import { Stepper, StepperDescription, StepperIndicator, StepperItem, StepperSeparator, StepperTitle, StepperTrigger } from '@/registry/new-york-v4/ui/stepper'
+
+const steps = [
+  {
+    step: 1,
+    title: 'Address',
+    description: 'Add your addres',
+    icon: BookUser,
+  },
+  {
+    step: 2,
+    title: 'Shipping',
+    description: 'Set your preferred',
+    icon: Truck,
+  },
+  {
+    step: 3,
+    title: 'Payment',
+    description: 'Add any payment',
+    icon: CreditCard,
+  },
+  {
+    step: 4,
+    title: 'Checkout',
+    description: 'Confirm your order',
+  },
+]
+</script>
+
+<template>
+  <Stepper class="flex w-1/2 items-start gap-2">
+    <StepperItem
+      v-for="item in steps"
+      :key="item.step"
+      :step="item.step"
+      class="relative flex w-full flex-col items-center justify-center"
+    >
+      <StepperTrigger>
+        <StepperIndicator v-slot="{ step }" class="bg-muted">
+          <template v-if="item.icon">
+            <component :is="item.icon" class="w-4 h-4" />
+          </template>
+          <span v-else>{{ step }}</span>
+        </StepperIndicator>
+      </StepperTrigger>
+      <StepperSeparator
+        v-if="item.step !== steps[steps.length - 1].step"
+        class="absolute left-[calc(50%+20px)] right-[calc(-50%+10px)] top-5 block h-0.5 shrink-0 rounded-full bg-muted group-data-[state=completed]:bg-primary"
+      />
+      <div class="flex flex-col items-center">
+        <StepperTitle>
+          {{ item.title }}
+        </StepperTitle>
+        <StepperDescription>
+          {{ item.description }}
+        </StepperDescription>
+      </div>
+    </StepperItem>
+  </Stepper>
+</template>

--- a/apps/v4/pages/index.vue
+++ b/apps/v4/pages/index.vue
@@ -120,6 +120,9 @@
     <ComponentWrapper name="Sonner">
       <LazySonnerDemo />
     </ComponentWrapper>
+    <ComponentWrapper name="Stepper">
+      <LazyStepperDemo />
+    </ComponentWrapper>
     <ComponentWrapper name="Switch">
       <LazySwitchDemo />
     </ComponentWrapper>

--- a/apps/v4/registry/new-york-v4/ui/stepper/StepperIndicator.vue
+++ b/apps/v4/registry/new-york-v4/ui/stepper/StepperIndicator.vue
@@ -14,6 +14,7 @@ const forwarded = useForwardProps(delegatedProps)
 
 <template>
   <StepperIndicator
+    v-slot="slotProps"
     v-bind="forwarded"
     :class="cn(
       'inline-flex items-center justify-center rounded-full text-muted-foreground/50 w-8 h-8',
@@ -26,6 +27,6 @@ const forwarded = useForwardProps(delegatedProps)
       props.class,
     )"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </StepperIndicator>
 </template>

--- a/apps/www/src/registry/default/ui/stepper/StepperIndicator.vue
+++ b/apps/www/src/registry/default/ui/stepper/StepperIndicator.vue
@@ -15,6 +15,7 @@ const forwarded = useForwardProps(delegatedProps)
 
 <template>
   <StepperIndicator
+    v-slot="slotProps"
     v-bind="forwarded"
     :class="cn(
       'inline-flex items-center justify-center rounded-full text-muted-foreground/50 w-10 h-10',
@@ -27,6 +28,6 @@ const forwarded = useForwardProps(delegatedProps)
       props.class,
     )"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </StepperIndicator>
 </template>

--- a/apps/www/src/registry/new-york/ui/stepper/StepperIndicator.vue
+++ b/apps/www/src/registry/new-york/ui/stepper/StepperIndicator.vue
@@ -14,6 +14,7 @@ const forwarded = useForwardProps(delegatedProps)
 
 <template>
   <StepperIndicator
+    v-slot="slotProps"
     v-bind="forwarded"
     :class="cn(
       'inline-flex items-center justify-center rounded-full text-muted-foreground/50 w-8 h-8',
@@ -26,6 +27,6 @@ const forwarded = useForwardProps(delegatedProps)
       props.class,
     )"
   >
-    <slot />
+    <slot v-bind="slotProps" />
   </StepperIndicator>
 </template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#1311


<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

resolves #1311 

when we use the component, if we look at the `reka-ui` https://reka-ui.com/docs/components/stepper#indicator api, there is a default slot `step`, but not in `v4`, not in the default `registry`, it is impossible to get this slot because it does not fit into the default slot

so the solution is just pull out the `slotProps` slot through the `v-slot` and bind it in the default slot

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
