### PR TITLE
fix: show only one theme picker on smaller screen

### DIFF
--- a/apps/www/.vitepress/theme/layout/ThemingLayout.vue
+++ b/apps/www/.vitepress/theme/layout/ThemingLayout.vue
@@ -83,7 +83,7 @@ watch(radius, (radius) => {
 
         <Popover>
           <PopoverTrigger as-child>
-            <Button size="sm">
+            <Button size="sm" class="max-md:hidden">
               Customize
             </Button>
           </PopoverTrigger>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Show only one theme picker on screen smaller than `md` size.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

Before:
![image](https://github.com/user-attachments/assets/2fc4489c-80f2-4ad7-8db5-0c4c87348ad6)

After:
![image](https://github.com/user-attachments/assets/7f7184a4-ae66-4f07-9149-6caa37c8d936)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
