### PR TITLE
docs: add tsconfig alias setup before shadcn-vue init step

### DIFF
--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -35,8 +35,9 @@ npm install -D typescript
 ```bash
 npm install tailwindcss @tailwindcss/vite
 ```
-
-Replace everything in `assets/css/tailwind.css` with the following:
+make file with the following:
+For Nuxt v4: `app/assets/css/tailwind.css`
+For Nuxt v3: `/assets/css/tailwind.css`
 
 ```css title="assets/css/tailwind.css"
 @import "tailwindcss";
@@ -238,7 +239,19 @@ npx nuxi prepare
 ```
 
 ### Run the CLI
-
+Update your tsconfig.json with the following configuration.
+```
+// ...
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./app/*"],
+      "~/*": ["./app/*"]
+    }
+  }
+}
+```
 Run the `shadcn-vue` init command to setup your project:
 
 ```bash


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR updates the Nuxt + Tailwind + shadcn-vue integration guide to include 
`tsconfig.json` alias configuration before running `shadcn-vue init`. 

This helps avoid path resolution issues and ensures a smoother setup process.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ x] I have updated the documentation accordingly.
