### PR TITLE
fix: Use destructive instead of destructive-foreground in form components

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/form/FormLabel.vue
+++ b/apps/v4/registry/new-york-v4/ui/form/FormLabel.vue
@@ -15,7 +15,7 @@ const { error, formItemId } = useFormField()
     data-slot="form-label"
     :data-error="!!error"
     :class="cn(
-      'data-[error=true]:text-destructive-foreground',
+      'data-[error=true]:text-destructive',
       props.class,
     )"
     :for="formItemId"

--- a/apps/v4/registry/new-york-v4/ui/form/FormMessage.vue
+++ b/apps/v4/registry/new-york-v4/ui/form/FormMessage.vue
@@ -18,6 +18,6 @@ const { name, formMessageId } = useFormField()
     data-slot="form-message"
     as="p"
     :name="toValue(name)"
-    :class="cn('text-destructive-foreground text-sm', props.class)"
+    :class="cn('text-destructive text-sm', props.class)"
   />
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

Fixes https://github.com/unovue/shadcn-vue/issues/1307

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Visibility issue. In general bug is there with a bunch of components

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. *(no doc updates needed)*
