### PR TITLE
feat(icons): Add support for tabler icons

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -21,6 +21,7 @@
     "@internationalized/date": "catalog:",
     "@radix-icons/vue": "^1.0.0",
     "@stackblitz/sdk": "^1.11.0",
+    "@tabler/icons-vue": "^1.0.0",
     "@tanstack/vue-table": "^8.21.3",
     "@unovis/ts": "^1.5.2",
     "@unovis/vue": "^1.5.2",

--- a/apps/www/src/public/r/icons/index.json
+++ b/apps/www/src/public/r/icons/index.json
@@ -1,150 +1,187 @@
 {
   "AlertCircle": {
     "lucide": "AlertCircle",
-    "radix": "ExclamationTriangleIcon"
+    "radix": "ExclamationTriangleIcon",
+    "tabler": "IconExclamationCircle"
   },
   "ArrowLeft": {
     "lucide": "ArrowLeft",
-    "radix": "ArrowLeftIcon"
+    "radix": "ArrowLeftIcon",
+    "tabler": "IconArrowLeft"
   },
   "ArrowRight": {
     "lucide": "ArrowRight",
-    "radix": "ArrowRightIcon"
+    "radix": "ArrowRightIcon",
+    "tabler": "IconArrowRight"
   },
   "ArrowUpDown": {
     "lucide": "ArrowUpDown",
-    "radix": "CaretSortIcon"
+    "radix": "CaretSortIcon",
+    "tabler": "IconArrowsSort"
   },
   "BellRing": {
     "lucide": "BellRing",
-    "radix": "BellIcon"
+    "radix": "BellIcon",
+    "tabler": "IconBellRinging"
   },
   "Bold": {
     "lucide": "Bold",
-    "radix": "FontBoldIcon"
+    "radix": "FontBoldIcon",
+    "tabler": "IconBold"
   },
   "Calculator": {
     "lucide": "Calculator",
-    "radix": "ComponentPlaceholderIcon"
+    "radix": "ComponentPlaceholderIcon",
+    "tabler": "IconCalculator"
   },
   "Calendar": {
     "lucide": "Calendar",
-    "radix": "CalendarIcon"
+    "radix": "CalendarIcon",
+    "tabler": "IconCalendar"
   },
   "Check": {
     "lucide": "Check",
-    "radix": "CheckIcon"
+    "radix": "CheckIcon",
+    "tabler": "IconCheck"
   },
   "ChevronDown": {
     "lucide": "ChevronDown",
-    "radix": "ChevronDownIcon"
+    "radix": "ChevronDownIcon",
+    "tabler": "IconChevronDown"
   },
   "ChevronLeft": {
     "lucide": "ChevronLeft",
-    "radix": "ChevronLeftIcon"
+    "radix": "ChevronLeftIcon",
+    "tabler": "IconChevronLeft"
   },
   "ChevronRight": {
     "lucide": "ChevronRight",
-    "radix": "ChevronRightIcon"
+    "radix": "ChevronRightIcon",
+    "tabler": "IconChevronRight"
   },
   "ChevronUp": {
     "lucide": "ChevronUp",
-    "radix": "ChevronUpIcon"
+    "radix": "ChevronUpIcon",
+    "tabler": "IconChevronUp"
   },
   "ChevronsUpDown": {
     "lucide": "ChevronsUpDown",
-    "radix": "CaretSortIcon"
+    "radix": "CaretSortIcon",
+    "tabler": "IconArrowsSort"
   },
   "Circle": {
     "lucide": "Circle",
-    "radix": "DotFilledIcon"
+    "radix": "DotFilledIcon",
+    "tabler": "IconCircle"
   },
   "Copy": {
     "lucide": "Copy",
-    "radix": "CopyIcon"
+    "radix": "CopyIcon",
+    "tabler": "IconCopy"
   },
   "CreditCard": {
     "lucide": "CreditCard",
-    "radix": "ComponentPlaceholderIcon"
+    "radix": "ComponentPlaceholderIcon",
+    "tabler": "IconCreditCard"
   },
   "GripVertical": {
     "lucide": "GripVertical",
-    "radix": "DragHandleDots2Icon"
+    "radix": "DragHandleDots2Icon",
+    "tabler": "IconGripVertical"
   },
   "Italic": {
     "lucide": "Italic",
-    "radix": "FontItalicIcon"
+    "radix": "FontItalicIcon",
+    "tabler": "IconItalic"
   },
   "Loader2": {
     "lucide": "Loader2",
-    "radix": "ReloadIcon"
+    "radix": "ReloadIcon",
+    "tabler": "IconLoader2"
   },
   "Mail": {
     "lucide": "Mail",
-    "radix": "EnvelopeClosedIcon"
+    "radix": "EnvelopeClosedIcon",
+    "tabler": "IconMail"
   },
   "MailOpen": {
     "lucide": "MailOpen",
-    "radix": "EnvelopeOpenIcon"
+    "radix": "EnvelopeOpenIcon",
+    "tabler": "IconMailOpened"
   },
   "Minus": {
     "lucide": "Minus",
-    "radix": "MinusIcon"
+    "radix": "MinusIcon",
+    "tabler": "IconMinus"
   },
   "Moon": {
     "lucide": "Moon",
-    "radix": "MoonIcon"
+    "radix": "MoonIcon",
+    "tabler": "IconMoon"
   },
   "MoreHorizontal": {
     "lucide": "MoreHorizontal",
-    "radix": "DotsHorizontalIcon"
+    "radix": "DotsHorizontalIcon",
+    "tabler": "IconDots"
   },
   "PanelLeft": {
     "lucide": "PanelLeft",
-    "radix": "ViewVerticalIcon"
+    "radix": "ViewVerticalIcon",
+    "tabler": "IconLayoutSidebar"
   },
   "Plus": {
     "lucide": "Plus",
-    "radix": "PlusIcon"
+    "radix": "PlusIcon",
+    "tabler": "IconPlus"
   },
   "Search": {
     "lucide": "Search",
-    "radix": "MagnifyingGlassIcon"
+    "radix": "MagnifyingGlassIcon",
+    "tabler": "IconSearch"
   },
   "Send": {
     "lucide": "Send",
-    "radix": "PaperPlaneIcon"
+    "radix": "PaperPlaneIcon",
+    "tabler": "IconSend"
   },
   "Settings": {
     "lucide": "Settings",
-    "radix": "GearIcon"
+    "radix": "GearIcon",
+    "tabler": "IconSettings"
   },
   "Slash": {
     "lucide": "Slash",
-    "radix": "SlashIcon"
+    "radix": "SlashIcon",
+    "tabler": "IconSlash"
   },
   "Smile": {
     "lucide": "Smile",
-    "radix": "FaceIcon"
+    "radix": "FaceIcon",
+    "tabler": "IconMoodSmile"
   },
   "Sun": {
     "lucide": "Sun",
-    "radix": "SunIcon"
+    "radix": "SunIcon",
+    "tabler": "IconSun"
   },
   "Terminal": {
     "lucide": "Terminal",
-    "radix": "RocketIcon"
+    "radix": "RocketIcon",
+    "tabler": "IconTerminal"
   },
   "Underline": {
     "lucide": "Underline",
-    "radix": "UnderlineIcon"
+    "radix": "UnderlineIcon",
+    "tabler": "IconUnderline"
   },
   "User": {
     "lucide": "User",
-    "radix": "PersonIcon"
+    "radix": "PersonIcon",
+    "tabler": "IconUser"
   },
   "X": {
     "lucide": "X",
-    "radix": "Cross2Icon"
+    "radix": "Cross2Icon",
+    "tabler": "IconX"
   }
 }

--- a/apps/www/src/registry/registry-icons.ts
+++ b/apps/www/src/registry/registry-icons.ts
@@ -9,6 +9,11 @@ export const iconLibraries = {
     package: "@radix-icons/vue",
     import: "@radix-icons/vue",
   },
+  tabler: {
+    name: "@tabler/icons-vue",
+    package: "@tabler/icons-vue",
+    import: "@tabler/icons-vue",
+  },
 } as const
 
 export const icons: Record<
@@ -18,149 +23,186 @@ export const icons: Record<
   AlertCircle: {
     lucide: "AlertCircle",
     radix: "ExclamationTriangleIcon",
+    tabler: "IconExclamationCircle",
   },
   ArrowLeft: {
     lucide: "ArrowLeft",
     radix: "ArrowLeftIcon",
+    tabler: "IconArrowLeft",
   },
   ArrowRight: {
     lucide: "ArrowRight",
     radix: "ArrowRightIcon",
+    tabler: "IconArrowRight",
   },
   ArrowUpDown: {
     lucide: "ArrowUpDown",
     radix: "CaretSortIcon",
+    tabler: "IconArrowsSort",
   },
   BellRing: {
     lucide: "BellRing",
     radix: "BellIcon",
+    tabler: "IconBellRinging",
   },
   Bold: {
     lucide: "Bold",
     radix: "FontBoldIcon",
+    tabler: "IconBold",
   },
   Calculator: {
     lucide: "Calculator",
     radix: "ComponentPlaceholderIcon",
+    tabler: "IconCalculator",
   },
   Calendar: {
     lucide: "Calendar",
     radix: "CalendarIcon",
+    tabler: "IconCalendar",
   },
   Check: {
     lucide: "Check",
     radix: "CheckIcon",
+    tabler: "IconCheck",
   },
   ChevronDown: {
     lucide: "ChevronDown",
     radix: "ChevronDownIcon",
+    tabler: "IconChevronDown",
   },
   ChevronLeft: {
     lucide: "ChevronLeft",
     radix: "ChevronLeftIcon",
+    tabler: "IconChevronLeft",
   },
   ChevronRight: {
     lucide: "ChevronRight",
     radix: "ChevronRightIcon",
+    tabler: "IconChevronRight",
   },
   ChevronUp: {
     lucide: "ChevronUp",
     radix: "ChevronUpIcon",
+    tabler: "IconChevronUp",
   },
   ChevronsUpDown: {
     lucide: "ChevronsUpDown",
     radix: "CaretSortIcon",
+    tabler: "IconSelector",
   },
   Circle: {
     lucide: "Circle",
     radix: "DotFilledIcon",
+    tabler: "IconCircle",
   },
   Copy: {
     lucide: "Copy",
     radix: "CopyIcon",
+    tabler: "IconCopy",
   },
   CreditCard: {
     lucide: "CreditCard",
     radix: "ComponentPlaceholderIcon",
+    tabler: "IconCreditCard",
   },
   GripVertical: {
     lucide: "GripVertical",
     radix: "DragHandleDots2Icon",
+    tabler: "IconGripVertical",
   },
   Italic: {
     lucide: "Italic",
     radix: "FontItalicIcon",
+    tabler: "IconItalic",
   },
   Loader2: {
     lucide: "Loader2",
     radix: "ReloadIcon",
+    tabler: "IconLoader2",
   },
   Mail: {
     lucide: "Mail",
     radix: "EnvelopeClosedIcon",
+    tabler: "IconMail",
   },
   MailOpen: {
     lucide: "MailOpen",
     radix: "EnvelopeOpenIcon",
+    tabler: "IconMailOpened",
   },
   Minus: {
     lucide: "Minus",
     radix: "MinusIcon",
+    tabler: "IconMinus",
   },
   Moon: {
     lucide: "Moon",
     radix: "MoonIcon",
+    tabler: "IconMoon",
   },
   MoreHorizontal: {
     lucide: "MoreHorizontal",
     radix: "DotsHorizontalIcon",
+    tabler: "IconDots",
   },
   PanelLeft: {
     lucide: "PanelLeft",
     radix: "ViewVerticalIcon",
+    tabler: "IconLayoutSidebar",
   },
   Plus: {
     lucide: "Plus",
     radix: "PlusIcon",
+    tabler: "IconPlus",
   },
   Search: {
     lucide: "Search",
     radix: "MagnifyingGlassIcon",
+    tabler: "IconSearch",
   },
   Send: {
     lucide: "Send",
     radix: "PaperPlaneIcon",
+    tabler: "IconSend",
   },
   Settings: {
     lucide: "Settings",
     radix: "GearIcon",
+    tabler: "IconSettings",
   },
   Slash: {
     lucide: "Slash",
     radix: "SlashIcon",
+    tabler: "IconSlash",
   },
   Smile: {
     lucide: "Smile",
     radix: "FaceIcon",
+    tabler: "IconMoodSmile",
   },
   Sun: {
     lucide: "Sun",
     radix: "SunIcon",
+    tabler: "IconSun",
   },
   Terminal: {
     lucide: "Terminal",
     radix: "RocketIcon",
+    tabler: "IconTerminal",
   },
   Underline: {
     lucide: "Underline",
     radix: "UnderlineIcon",
+    tabler: "IconUnderline",
   },
   User: {
     lucide: "User",
     radix: "PersonIcon",
+    tabler: "IconUser",
   },
   X: {
     lucide: "X",
     radix: "Cross2Icon",
+    tabler: "IconX",
   },
 } as const

--- a/packages/cli/src/utils/icon-libraries.ts
+++ b/packages/cli/src/utils/icon-libraries.ts
@@ -9,4 +9,9 @@ export const ICON_LIBRARIES = {
     package: '@radix-icons/vue',
     import: '@radix-icons/vue',
   },
+  tabler: {
+    name: '@tabler/icons-vue',
+    package: '@tabler/icons-vue',
+    import: '@tabler/icons-vue',
+  },
 }

--- a/packages/cli/src/utils/transformers/transform-icons.ts
+++ b/packages/cli/src/utils/transformers/transform-icons.ts
@@ -32,7 +32,7 @@ export function transformIcons(opts: TransformOpts, registryIcons: Record<string
         traverseScriptAST(scriptAST, {
 
           visitImportDeclaration(path) {
-            if (![ICON_LIBRARIES.radix.import, ICON_LIBRARIES.lucide.import].includes(`${path.node.source.value}`))
+            if (![ICON_LIBRARIES.tabler.import, ICON_LIBRARIES.radix.import, ICON_LIBRARIES.lucide.import].includes(`${path.node.source.value}`))
               return this.traverse(path)
 
             for (const specifier of path.node.specifiers ?? []) {

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -32,6 +32,7 @@ it.skip('init config-full', async () => {
       'tailwind-merge',
       'lucide-vue-next',
       '@radix-icons/vue',
+      '@tabler/icons-vue',
     ],
     registryDependencies: [],
     tailwind: {
@@ -100,6 +101,7 @@ it.skip('init config-full', async () => {
       'tailwind-merge',
       'reka-ui',
       '@radix-icons/vue',
+      '@tabler/icons-vue',
     ],
     {
       cwd: targetDir,

--- a/packages/cli/test/utils/__snapshots__/transform-icons.test.ts.snap
+++ b/packages/cli/test/utils/__snapshots__/transform-icons.test.ts.snap
@@ -38,3 +38,16 @@ import { Primitive } from "reka-ui";
 </template>
 "
 `;
+
+exports[`transformIcons > transforms tabler icons 1`] = `
+"<script setup>
+import { IconCheck } from '@tabler/icons-vue';
+import { Primitive } from "reka-ui";
+</script>
+
+<template>
+  <IconCheck />
+  <Primitive />
+</template>
+"
+`;

--- a/packages/cli/test/utils/transform-icons.test.ts
+++ b/packages/cli/test/utils/transform-icons.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, it } from 'vitest'
 import { transform } from '../../src/utils/transformers'
 
 describe('transformIcons', () => {
+  it('transforms tabler icons', async () => {
+    const result = await transform({
+      filename: 'app.vue',
+      raw: `<script lang="ts" setup>
+      import { Check } from 'lucide-vue-next'
+      import { Primitive } from 'reka-ui'
+      </script>
+
+      <template>
+        <Check />
+        <Primitive />
+      </template>
+      `,
+      config: {
+        iconLibrary: 'tabler',
+      },
+    })
+    expect(result).toMatchSnapshot()
+  })
+
   it('transforms radix icons', async () => {
     const result = await transform({
       filename: 'app.vue',


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 [Linked issue](https://github.com/unovue/shadcn-vue/issues/1387)

### ❓ Feature update

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

These changes add support for [Tabler icons](https://tabler.io/icons). Tabler icons are used in the original Shadcn package and provide a much larger range of free and scalable icons.

### 📸 Screenshots (if appropriate)

N/A

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
