### PR TITLE
fix: StepperSeparator should use background color

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/stepper/StepperSeparator.vue
+++ b/apps/v4/registry/new-york-v4/ui/stepper/StepperSeparator.vue
@@ -20,7 +20,7 @@ const forwarded = useForwardProps(delegatedProps)
       // Disabled
       'group-data-[disabled]:bg-muted group-data-[disabled]:opacity-50',
       // Completed
-      'group-data-[state=completed]:bg-accent-foreground',
+      'group-data-[state=completed]:bg-accent',
       props.class,
     )"
   />


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Similar to https://github.com/unovue/shadcn-vue/pull/1380

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The only other case I found in `ui`, where background was not set but foreground was used. The others are `text-muted-foreground` and `bg-background text-foreground` which should be good. Some `blocks` have this pattern too.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
