### PR TITLE
Feat: add color for buttons + refine variants

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/button/Button.vue
+++ b/apps/v4/registry/new-york-v4/ui/button/Button.vue
@@ -5,16 +5,45 @@ import type { ButtonVariants } from "."
 import { Primitive } from "reka-ui"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "."
+import { computed } from "vue"
 
 interface Props extends PrimitiveProps {
   variant?: ButtonVariants["variant"]
   size?: ButtonVariants["size"]
+  color?: ButtonVariants["color"]
   class?: HTMLAttributes["class"]
 }
 
 const props = withDefaults(defineProps<Props>(), {
   as: "button",
-})
+});
+
+// map legacy variants → new props
+const resolvedVariant = computed(() => {
+  switch (props.variant) {
+    case "default":
+      return "solid"
+    case "destructive":
+      return "solid"
+    case "secondary":
+      return "solid"
+    default:
+      return props.variant
+  }
+});
+
+const resolvedColor = computed(() => {
+  switch (props.variant) {
+    case "default":
+      return "primary"
+    case "destructive":
+      return "error"
+    case "secondary":
+      return "secondary"
+    default:
+      return props.color ?? "primary"
+  }
+});
 </script>
 
 <template>
@@ -22,7 +51,16 @@ const props = withDefaults(defineProps<Props>(), {
     data-slot="button"
     :as="as"
     :as-child="asChild"
-    :class="cn(buttonVariants({ variant, size }), props.class)"
+    :class="
+      cn(
+        buttonVariants({
+          variant: resolvedVariant,
+          size,
+          color: resolvedColor,
+        }),
+        props.class
+      )
+    "
   >
     <slot />
   </Primitive>

--- a/apps/v4/registry/new-york-v4/ui/button/index.ts
+++ b/apps/v4/registry/new-york-v4/ui/button/index.ts
@@ -4,34 +4,320 @@ import { cva } from "class-variance-authority"
 export { default as Button } from "./Button.vue"
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "rounded-md font-medium flex items-center justify-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors focus-visible:outline-none",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+        solid: "",
+        outline: "",
+        soft: "",
+        subtle: "",
+        ghost: "",
+        link: "",
+        default: "",
+        destructive: "",
+        secondary: "",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        xs: "px-2 py-1 text-xs gap-1",
+        sm: "px-2.5 py-1.5 text-xs gap-1.5",
+        md: "px-2.5 py-1.5 text-sm gap-1.5",
+        lg: "px-3 py-2 text-sm gap-2",
+        xl: "px-3 py-2 text-base gap-2",
+      },
+      color: {
+        primary: "",
+        secondary: "",
+        success: "",
+        info: "",
+        warning: "",
+        error: "",
+        neutral: "",
       },
     },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  },
-)
+    compoundVariants: [
+      // ----------------
+      // SOLID
+      // ----------------
+      {
+        variant: ["solid", "default"],
+        color: "primary",
+        class:
+          "text-primary-content bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary",
+      },
+      {
+        variant: ["solid", "secondary"],
+        color: "secondary",
+        class:
+          "text-secondary-content bg-secondary hover:bg-secondary/75 active:bg-secondary/75 disabled:bg-secondary aria-disabled:bg-secondary focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-secondary",
+      },
+      {
+        variant: ["solid", "destructive"],
+        color: "error",
+        class:
+          "text-error-content bg-error hover:bg-error/75 active:bg-error/75 disabled:bg-error aria-disabled:bg-error focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-error",
+      },
+      {
+        variant: "solid",
+        color: "success",
+        class:
+          "text-success-content bg-success hover:bg-success/75 active:bg-success/75 disabled:bg-success aria-disabled:bg-success focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-success",
+      },
+      {
+        variant: "solid",
+        color: "info",
+        class:
+          "text-info-content bg-info hover:bg-info/75 active:bg-info/75 disabled:bg-info aria-disabled:bg-info focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-info",
+      },
+      {
+        variant: "solid",
+        color: "warning",
+        class:
+          "text-warning-content bg-warning hover:bg-warning/75 active:bg-warning/75 disabled:bg-warning aria-disabled:bg-warning focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-warning",
+      },
+      {
+        variant: "solid",
+        color: "neutral",
+        class:
+          "text-inverted bg-inverted hover:bg-inverted/90 active:bg-inverted/90 disabled:bg-inverted aria-disabled:bg-inverted focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-inverted",
+      },
 
-export type ButtonVariants = VariantProps<typeof buttonVariants>
+      // ----------------
+      // OUTLINE
+      // ----------------
+      {
+        variant: "outline",
+        color: "primary",
+        class:
+          "ring ring-inset ring-primary/50 text-primary hover:bg-primary/10 active:bg-primary/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:ring-2 focus-visible:ring-primary",
+      },
+      {
+        variant: "outline",
+        color: "secondary",
+        class:
+          "ring ring-inset ring-secondary/50 text-secondary hover:bg-secondary/10 active:bg-secondary/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:ring-2 focus-visible:ring-secondary",
+      },
+      {
+        variant: "outline",
+        color: "success",
+        class:
+          "ring ring-inset ring-success/50 text-success hover:bg-success/10 active:bg-success/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:ring-2 focus-visible:ring-success",
+      },
+      {
+        variant: "outline",
+        color: "info",
+        class:
+          "ring ring-inset ring-info/50 text-info hover:bg-info/10 active:bg-info/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:ring-2 focus-visible:ring-info",
+      },
+      {
+        variant: "outline",
+        color: "warning",
+        class:
+          "ring ring-inset ring-warning/50 text-warning hover:bg-warning/10 active:bg-warning/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:ring-2 focus-visible:ring-warning",
+      },
+      {
+        variant: "outline",
+        color: "error",
+        class:
+          "ring ring-inset ring-error/50 text-error hover:bg-error/10 active:bg-error/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:ring-2 focus-visible:ring-error",
+      },
+      {
+        variant: "outline",
+        color: "neutral",
+        class:
+          "ring ring-inset ring-accented text-default bg-default hover:bg-elevated active:bg-elevated disabled:bg-default aria-disabled:bg-default focus-visible:ring-2 focus-visible:ring-inverted",
+      },
+
+      // ----------------
+      // SOFT
+      // ----------------
+      {
+        variant: "soft",
+        color: "primary",
+        class:
+          "text-primary bg-primary/10 hover:bg-primary/15 active:bg-primary/15 focus-visible:bg-primary/15 disabled:bg-primary/10 aria-disabled:bg-primary/10",
+      },
+      {
+        variant: "soft",
+        color: "secondary",
+        class:
+          "text-secondary bg-secondary/10 hover:bg-secondary/15 active:bg-secondary/15 focus-visible:bg-secondary/15 disabled:bg-secondary/10 aria-disabled:bg-secondary/10",
+      },
+      {
+        variant: "soft",
+        color: "success",
+        class:
+          "text-success bg-success/10 hover:bg-success/15 active:bg-success/15 focus-visible:bg-success/15 disabled:bg-success/10 aria-disabled:bg-success/10",
+      },
+      {
+        variant: "soft",
+        color: "info",
+        class:
+          "text-info bg-info/10 hover:bg-info/15 active:bg-info/15 focus-visible:bg-info/15 disabled:bg-info/10 aria-disabled:bg-info/10",
+      },
+      {
+        variant: "soft",
+        color: "warning",
+        class:
+          "text-warning bg-warning/10 hover:bg-warning/15 active:bg-warning/15 focus-visible:bg-warning/15 disabled:bg-warning/10 aria-disabled:bg-warning/10",
+      },
+      {
+        variant: "soft",
+        color: "error",
+        class:
+          "text-error bg-error/10 hover:bg-error/15 active:bg-error/15 focus-visible:bg-error/15 disabled:bg-error/10 aria-disabled:bg-error/10",
+      },
+      {
+        variant: "soft",
+        color: "neutral",
+        class:
+          "text-default bg-elevated hover:bg-accented/75 active:bg-accented/75 focus-visible:bg-accented/75 disabled:bg-elevated aria-disabled:bg-elevated",
+      },
+
+      // ----------------
+      // SUBTLE
+      // ----------------
+      {
+        variant: "subtle",
+        color: "primary",
+        class:
+          "text-primary ring ring-inset ring-primary/25 bg-primary/10 hover:bg-primary/15 active:bg-primary/15 disabled:bg-primary/10 aria-disabled:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary",
+      },
+      {
+        variant: "subtle",
+        color: "secondary",
+        class:
+          "text-secondary ring ring-inset ring-secondary/25 bg-secondary/10 hover:bg-secondary/15 active:bg-secondary/15 disabled:bg-secondary/10 aria-disabled:bg-secondary/10 focus-visible:ring-2 focus-visible:ring-secondary",
+      },
+      {
+        variant: "subtle",
+        color: "success",
+        class:
+          "text-success ring ring-inset ring-success/25 bg-success/10 hover:bg-success/15 active:bg-success/15 disabled:bg-success/10 aria-disabled:bg-success/10 focus-visible:ring-2 focus-visible:ring-success",
+      },
+      {
+        variant: "subtle",
+        color: "info",
+        class:
+          "text-info ring ring-inset ring-info/25 bg-info/10 hover:bg-info/15 active:bg-info/15 disabled:bg-info/10 aria-disabled:bg-info/10 focus-visible:ring-2 focus-visible:ring-info",
+      },
+      {
+        variant: "subtle",
+        color: "warning",
+        class:
+          "text-warning ring ring-inset ring-warning/25 bg-warning/10 hover:bg-warning/15 active:bg-warning/15 disabled:bg-warning/10 aria-disabled:bg-warning/10 focus-visible:ring-2 focus-visible:ring-warning",
+      },
+      {
+        variant: "subtle",
+        color: "error",
+        class:
+          "text-error ring ring-inset ring-error/25 bg-error/10 hover:bg-error/15 active:bg-error/15 disabled:bg-error/10 aria-disabled:bg-error/10 focus-visible:ring-2 focus-visible:ring-error",
+      },
+      {
+        variant: "subtle",
+        color: "neutral",
+        class:
+          "ring ring-inset ring-accented text-default bg-elevated hover:bg-accented/75 active:bg-accented/75 disabled:bg-elevated aria-disabled:bg-elevated focus-visible:ring-2 focus-visible:ring-inverted",
+      },
+
+      // ----------------
+      // GHOST
+      // ----------------
+      {
+        variant: "ghost",
+        color: "primary",
+        class:
+          "text-primary hover:bg-primary/10 active:bg-primary/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:bg-primary/10",
+      },
+      {
+        variant: "ghost",
+        color: "secondary",
+        class:
+          "text-secondary hover:bg-secondary/10 active:bg-secondary/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:bg-secondary/10",
+      },
+      {
+        variant: "ghost",
+        color: "success",
+        class:
+          "text-success hover:bg-success/10 active:bg-success/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:bg-success/10",
+      },
+      {
+        variant: "ghost",
+        color: "info",
+        class:
+          "text-info hover:bg-info/10 active:bg-info/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:bg-info/10",
+      },
+      {
+        variant: "ghost",
+        color: "warning",
+        class:
+          "text-warning hover:bg-warning/10 active:bg-warning/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:bg-warning/10",
+      },
+      {
+        variant: "ghost",
+        color: "error",
+        class:
+          "text-error hover:bg-error/10 active:bg-error/10 disabled:bg-transparent aria-disabled:bg-transparent focus-visible:bg-error/10",
+      },
+      {
+        variant: "ghost",
+        color: "neutral",
+        class:
+          "text-default hover:bg-elevated active:bg-elevated focus-visible:bg-elevated hover:disabled:bg-transparent dark:hover:disabled:bg-transparent hover:aria-disabled:bg-transparent dark:hover:aria-disabled:bg-transparent",
+      },
+
+      // ----------------
+      // LINK
+      // ----------------
+      {
+        variant: "link",
+        color: "primary",
+        class:
+          "text-primary hover:text-primary/75 active:text-primary/75 disabled:text-primary aria-disabled:text-primary focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary",
+      },
+      {
+        variant: "link",
+        color: "secondary",
+        class:
+          "text-secondary hover:text-secondary/75 active:text-secondary/75 disabled:text-secondary aria-disabled:text-secondary focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-secondary",
+      },
+      {
+        variant: "link",
+        color: "success",
+        class:
+          "text-success hover:text-success/75 active:text-success/75 disabled:text-success aria-disabled:text-success focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-success",
+      },
+      {
+        variant: "link",
+        color: "info",
+        class:
+          "text-info hover:text-info/75 active:text-info/75 disabled:text-info aria-disabled:text-info focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-info",
+      },
+      {
+        variant: "link",
+        color: "warning",
+        class:
+          "text-warning hover:text-warning/75 active:text-warning/75 disabled:text-warning aria-disabled:text-warning focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-warning",
+      },
+      {
+        variant: "link",
+        color: "error",
+        class:
+          "text-error hover:text-error/75 active:text-error/75 disabled:text-error aria-disabled:text-error focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-error",
+      },
+      {
+        variant: "link",
+        color: "neutral",
+        class:
+          "text-muted hover:text-default active:text-default disabled:text-muted aria-disabled:text-muted focus-visible:ring-inset focus-visible:ring-2 focus-visible:ring-inverted",
+      },
+    ],
+    defaultVariants: {
+      color: "primary",
+      variant: "solid",
+      size: "md",
+    },
+  }
+);
+
+export type ButtonVariants = VariantProps<typeof buttonVariants>;


### PR DESCRIPTION
i have added colors and variants to button component. now you can use color info or accent with variant outline or subtle or ... . Old usage like:
`<Button variant="default">Click</Button>`
✅ Still works.

New usage like:
```
<Button variant="solid" color="success" size="lg">Save</Button> 
<Button variant="subtle" color="info">Info</Button>
```
 ✅ Fully supported.

<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)
subtle: 
<img width="433" height="79" alt="{EA7813A6-D21D-4787-AF46-414DD2E8173E}" src="https://github.com/user-attachments/assets/b86cd8d6-bf42-47f4-b019-4766231b817d" />
subtle - secondary:
<img width="402" height="55" alt="{2DEA83F3-EAF5-4B58-B0FB-00E3A52762F3}" src="https://github.com/user-attachments/assets/15cec560-458e-4f43-ab55-cdfe570a20b5" />

solid: 
<img width="431" height="64" alt="{82377005-8243-4EA4-B8FE-B7A237A63EC8}" src="https://github.com/user-attachments/assets/ede99427-9438-47d1-87c3-20dbc3ee349a" />
solid - secondary:
<img width="415" height="65" alt="{57C718D1-1457-454A-B0A2-C8DA8C22042C}" src="https://github.com/user-attachments/assets/cfd85c86-8d3e-4c1e-acf6-277103546ba8" />

outline:
<img width="419" height="62" alt="{C90F3B49-FF22-4F37-9350-0CB5F89D5903}" src="https://github.com/user-attachments/assets/2f3cbdbc-4100-4dc6-abd4-5a482e5e8bbe" />
outline - secondary: 
<img width="418" height="62" alt="{78E3B067-13D7-4652-911C-104F33622785}" src="https://github.com/user-attachments/assets/46a2edf8-baa7-41b1-8cd3-53774961d005" />

soft: 
<img width="421" height="64" alt="{FB65CDEC-3AEE-4DA8-AE44-DDCADE8F86E2}" src="https://github.com/user-attachments/assets/8cc83306-3c60-43c1-a9e2-42e4cbda6c19" />
soft - secondary: 
<img width="411" height="56" alt="{B6ADD6F3-88A2-4AA1-8F0F-CF5B9D23B1B3}" src="https://github.com/user-attachments/assets/36f6c935-96a3-422c-b8b2-516fd9afeb76" />


each one accept every colors
<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
