### PR TITLE
docs(nuxt): add tsconfig alias section and set componentDir to app/components/ui (Nuxt 4)

### DIFF
--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -236,6 +236,31 @@ export default defineNuxtPlugin((nuxtApp) => {
 })
 ```
 
+### Configure `tsconfig.json` (aliases)
+
+The shadcn-vue CLI validates import aliases from your `tsconfig.json`/`jsconfig.json`.
+Nuxt’s runtime aliases are not enough — you must define `compilerOptions.paths` explicitly.
+
+```json
+{
+  "references": [
+    { "path": "./.nuxt/tsconfig.app.json" },
+    { "path": "./.nuxt/tsconfig.server.json" },
+    { "path": "./.nuxt/tsconfig.shared.json" },
+    { "path": "./.nuxt/tsconfig.node.json" }
+  ],
+  "files": [],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "~/*": ["./*"],
+      "@/components/*": ["./app/components/*"]
+    }
+  }
+}
+```
+
 ### Configure `nuxt.config.ts`
 
 ```ts
@@ -248,8 +273,9 @@ export default defineNuxtConfig({
      */
     prefix: '',
     /**
-     * Directory that the component lives in.
-     * @default "./components/ui"
+     * Directory where components live.
+     * Nuxt 4 (app directory): './app/components/ui'
+     * Nuxt 3 (classic):       './components/ui'
      */
     componentDir: './components/ui'
   },

--- a/apps/www/src/content/docs/installation/nuxt.md
+++ b/apps/www/src/content/docs/installation/nuxt.md
@@ -251,7 +251,6 @@ Nuxt’s runtime aliases are not enough — you must define `compilerOptions.pat
   ],
   "files": [],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "~/*": ["./*"],


### PR DESCRIPTION
### 🔗 Linked issue
Refs: #1330, #1384  <!-- related PRs/discussions about Nuxt 4 tsconfig detection -->

### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description
**Explain**  
Nuxt 4 defaults to the `app/` directory and commonly uses a root `tsconfig.json` with project **references** only.  
The shadcn-vue CLI validates TS path aliases from `tsconfig.json/jsconfig.json`, so without explicit `compilerOptions.paths`, users can hit “No import alias found”.  
Also, pointing `componentDir` at `./components/ui` (Nuxt 3 style) can confuse Nuxt 4 users whose components live under `app/components/ui`.

**What this PR changes**
1. Add a **`tsconfig.json (aliases)`** section (before `nuxt.config.ts`) showing explicit `compilerOptions.paths`:
   - Keep `@/*` and `~/*` mapped to project root.
   - Map `@/components/*` → `./app/components/*` (Nuxt 4).
2. In **Configure `nuxt.config.ts`**, set  
   `shadcn.componentDir = './app/components/ui'` for Nuxt 4.
3. Doc note about ordering: run the **CLI** before `nuxi prepare` (or mention `mkdir -p app/components/ui`) to avoid the “Component directory does not exist …/components/ui” warning.
4. Keep Nuxt 3 instructions intact.

**Why**  
Ensures `init`/`add` pass alias validation and avoids confusing warnings for Nuxt 4 users.  
Forward-compatible with ongoing work to auto-detect tsconfig for Nuxt (#1330, #1384).

**Tested**
- Fresh Nuxt 4 app:
  - `npx shadcn-vue@latest init` ✅
  - `npx shadcn-vue@latest add button` ✅
  - `npx nuxi prepare` → no warnings ✅

### 📸 Screenshots (if appropriate)
N/A (docs-only)

### 📝 Checklist
- [x] I have linked an issue or discussion. (Refs: #1330, #1384)
- [x] I have updated the documentation accordingly.
