### PR TITLE
fix(module): replace hook with addComponentsDir and ignore everything in `ui` dir and scan components with oxc-parser

### DIFF
--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { addComponent, createResolver, defineNuxtModule } from '@nuxt/kit'
+import { addComponent, addComponentsDir, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { parseSync } from 'oxc-parser'
 
 // TODO: add test to make sure all registry is being parse correctly
@@ -45,11 +45,12 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Tell Nuxt to not scan `componentsDir` for auto imports as we will do it manually
     // See https://github.com/unovue/shadcn-vue/pull/528#discussion_r1590206268
-    nuxt.hook('components:dirs', (dirs) => {
-      dirs.unshift({
-        path: componentsPath,
-        extensions: [],
-      })
+    addComponentsDir({
+      path: componentsPath,
+      extensions: [],
+      ignore: ['**/*'],
+    }, {
+      prepend: true,
     })
 
     // Manually scan `componentsDir` for components and register them for auto imports


### PR DESCRIPTION


<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`shadcn-nuxt` is not working good in Nuxt 4 adding these changes will resolve the issue of  `Two component files resolving to the same name`

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
