### PR TITLE
fix(cli): update getTsconfig opts to support jsconfig.json

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -65,7 +65,7 @@ export async function resolveConfigPaths(
   )
 
   // Read tsconfig.json.
-  const tsConfig = await getTsconfig(tsConfigPath)
+  const tsConfig = await getTsconfig(tsConfigPath, isTypeScript ? undefined : 'jsconfig.json')
 
   if (tsConfig === null) {
     throw new Error(

--- a/packages/cli/src/utils/updaters/update-dependencies.ts
+++ b/packages/cli/src/utils/updaters/update-dependencies.ts
@@ -1,6 +1,6 @@
 import type { RegistryItem } from '@/src/schema'
 import type { Config } from '@/src/utils/get-config'
-import { ensureDependencyInstalled } from 'nypm'
+import { addDependency } from 'nypm'
 import { spinner } from '@/src/utils/spinner'
 
 export async function updateDependencies(
@@ -27,26 +27,20 @@ export async function updateDependencies(
   dependenciesSpinner?.start()
 
   if (dependencies?.length) {
-    const ensureDeps = dependencies.map(dep => ensureDependencyInstalled(dep, {
+    await addDependency(dependencies, {
       cwd: config.resolvedPaths.cwd,
-      // @ts-expect-error type error
       silent: true,
       dev: false,
-    }))
-
-    await Promise.all(ensureDeps)
+    })
   }
 
   // Install dev dependencies
   if (devDependencies?.length) {
-    const ensureDevDeps = devDependencies.map(dep => ensureDependencyInstalled(dep, {
+    await addDependency(devDependencies, {
       cwd: config.resolvedPaths.cwd,
-      // @ts-expect-error type error
       silent: true,
       dev: true,
-    }))
-
-    await Promise.all(ensureDevDeps)
+    })
   }
 
   dependenciesSpinner?.succeed()


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Close #1441

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Mostly tested TypeScript projects did not test jsconfig

https://github.com/privatenumber/get-tsconfig

For searching `jsconfig` should pass the `getTsconfig('.', 'jsconfig.json')`, `configName` to the function

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
