### PR TITLE
fix: input-group registry dependency btn inpt txtarea #1449

### DIFF
--- a/apps/v4/__registry__/index.ts
+++ b/apps/v4/__registry__/index.ts
@@ -1082,7 +1082,7 @@ export const Index: Record<string, any> = {
   name: "input-group",
   description: "",
   type: "registry:ui",
-  registryDependencies: [],
+  registryDependencies: ['button','input','textarea'],
   files: [{
     path: "registry/new-york-v4/ui/input-group/InputGroup.vue",
     type: "registry:ui",

--- a/apps/www/__registry__/index.ts
+++ b/apps/www/__registry__/index.ts
@@ -1133,7 +1133,7 @@ export const Index: Record<string, any> = {
       name: "input-group",
       description: "",
       type: "registry:ui",
-      registryDependencies: [],
+      registryDependencies: ['button','input','textarea'],
       files: [{
         path: "registry/new-york/ui/input-group/InputGroup.vue",
         type: "registry:ui",
@@ -7740,7 +7740,7 @@ export const Index: Record<string, any> = {
       name: "input-group",
       description: "",
       type: "registry:ui",
-      registryDependencies: [],
+      registryDependencies: ['button','input','textarea'],
       files: [{
         path: "registry/default/ui/input-group/InputGroup.vue",
         type: "registry:ui",


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

#1449

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #1449

input-group was not installing required related components`'button','input','textarea'` . Made changes to `registryDependencies` to install `'button','input','textarea'`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
