### PR TITLE
Lesser abstract reka-ui SelectItemText

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/select/SelectItem.vue
+++ b/apps/v4/registry/new-york-v4/ui/select/SelectItem.vue
@@ -36,8 +36,6 @@ const forwardedProps = useForwardProps(delegatedProps)
       </SelectItemIndicator>
     </span>
 
-    <SelectItemText>
-      <slot />
-    </SelectItemText>
+    <slot />
   </SelectItem>
 </template>

--- a/apps/www/src/registry/default/ui/select/SelectItem.vue
+++ b/apps/www/src/registry/default/ui/select/SelectItem.vue
@@ -35,8 +35,6 @@ const forwardedProps = useForwardProps(delegatedProps)
       </SelectItemIndicator>
     </span>
 
-    <SelectItemText>
-      <slot />
-    </SelectItemText>
+    <slot />
   </SelectItem>
 </template>

--- a/apps/www/src/registry/new-york/ui/select/SelectItem.vue
+++ b/apps/www/src/registry/new-york/ui/select/SelectItem.vue
@@ -35,8 +35,6 @@ const forwardedProps = useForwardProps(delegatedProps)
       </SelectItemIndicator>
     </span>
 
-    <SelectItemText>
-      <slot />
-    </SelectItemText>
+    <slot />
   </SelectItem>
 </template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Not an issue<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Without the ability to add classes to SelectItemText, I was unable to implement something like the screenshot below without w-full being defined on SelectItemText. I don't suggest that a breaking change like what I've included in this MR is the best approach, it means that 
```
<Select>
  <SelectTrigger class="w-[180px]">
    <SelectValue placeholder="Select a fruit" />
  </SelectTrigger>
  <SelectContent>
    <SelectGroup>
      <SelectLabel>Fruits</SelectLabel>
      <SelectItem value="apple">
        Apple
      </SelectItem>
    </SelectGroup>
  </SelectContent>
</Select>
```
would become
```
<Select>
  <SelectTrigger class="w-[180px]">
    <SelectValue placeholder="Select a fruit" />
  </SelectTrigger>
  <SelectContent>
    <SelectGroup>
      <SelectLabel>Fruits</SelectLabel>
      <SelectItem value="apple">
        <SelectItemText>
          Apple
        <SelectItemText />
      </SelectItem>
    </SelectGroup>
  </SelectContent>
</Select>
```
Which may be less like shadcn and therefore less desirable. Perhaps a way to pass css to the text at least?

### 📸 Screenshots (if appropriate)

<img width="287" height="294" alt="image" src="https://github.com/user-attachments/assets/dea41d49-65c5-4cc6-940d-81dbabc6deaf" />

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
