### PR TITLE
docs(v4): add more `ToggleGroup` demos, update docs

### DIFF
--- a/apps/v4/components/demo/ToggleGroupDefaultDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupDefaultDemo.vue
@@ -8,7 +8,7 @@ import {
 </script>
 
 <template>
-  <ToggleGroup variant="outline" type="multiple">
+  <ToggleGroup type="multiple">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
       <Bold class="size-4" />
     </ToggleGroupItem>

--- a/apps/v4/components/demo/ToggleGroupDefaultDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupDefaultDemo.vue
@@ -10,13 +10,13 @@ import {
 <template>
   <ToggleGroup type="multiple">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
-      <Bold class="size-4" />
+      <Bold class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
-      <Italic class="size-4" />
+      <Italic class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="strikethrough" aria-label="Toggle strikethrough">
-      <Underline class="size-4" />
+      <Underline class="h-4 w-4" />
     </ToggleGroupItem>
   </ToggleGroup>
 </template>

--- a/apps/v4/components/demo/ToggleGroupDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupDemo.vue
@@ -10,13 +10,13 @@ import {
 <template>
   <ToggleGroup variant="outline" type="multiple">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
-      <Bold class="size-4" />
+      <Bold class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
-      <Italic class="size-4" />
+      <Italic class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="strikethrough" aria-label="Toggle strikethrough">
-      <Underline class="size-4" />
+      <Underline class="h-4 w-4" />
     </ToggleGroupItem>
   </ToggleGroup>
 </template>

--- a/apps/v4/components/demo/ToggleGroupDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupDemo.vue
@@ -15,7 +15,7 @@ import {
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
       <Italic class="h-4 w-4" />
     </ToggleGroupItem>
-    <ToggleGroupItem value="strikethrough" aria-label="Toggle strikethrough">
+    <ToggleGroupItem value="underline" aria-label="Toggle underline">
       <Underline class="h-4 w-4" />
     </ToggleGroupItem>
   </ToggleGroup>

--- a/apps/v4/components/demo/ToggleGroupDisabledDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupDisabledDemo.vue
@@ -8,7 +8,7 @@ import {
 </script>
 
 <template>
-  <ToggleGroup variant="outline" type="multiple">
+  <ToggleGroup type="multiple" disabled>
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
       <Bold class="size-4" />
     </ToggleGroupItem>

--- a/apps/v4/components/demo/ToggleGroupDisabledDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupDisabledDemo.vue
@@ -10,13 +10,13 @@ import {
 <template>
   <ToggleGroup type="multiple" disabled>
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
-      <Bold class="size-4" />
+      <Bold class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
-      <Italic class="size-4" />
+      <Italic class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="strikethrough" aria-label="Toggle strikethrough">
-      <Underline class="size-4" />
+      <Underline class="h-4 w-4" />
     </ToggleGroupItem>
   </ToggleGroup>
 </template>

--- a/apps/v4/components/demo/ToggleGroupDisabledDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupDisabledDemo.vue
@@ -15,7 +15,7 @@ import {
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
       <Italic class="h-4 w-4" />
     </ToggleGroupItem>
-    <ToggleGroupItem value="strikethrough" aria-label="Toggle strikethrough">
+    <ToggleGroupItem value="underline" aria-label="Toggle underline">
       <Underline class="h-4 w-4" />
     </ToggleGroupItem>
   </ToggleGroup>

--- a/apps/v4/components/demo/ToggleGroupLargeDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupLargeDemo.vue
@@ -6,13 +6,13 @@ import { ToggleGroup, ToggleGroupItem } from '@/registry/new-york-v4/ui/toggle-g
 <template>
   <ToggleGroup type="multiple" size="lg">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
-      <Bold class="size-4" />
+      <Bold class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
-      <Italic class="size-4" />
+      <Italic class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="underline" aria-label="Toggle underline">
-      <Underline class="size-4" />
+      <Underline class="h-4 w-4" />
     </ToggleGroupItem>
   </ToggleGroup>
 </template>

--- a/apps/v4/components/demo/ToggleGroupLargeDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupLargeDemo.vue
@@ -1,21 +1,17 @@
 <script setup lang="ts">
 import { Bold, Italic, Underline } from 'lucide-vue-next'
-
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-} from '@/registry/new-york-v4/ui/toggle-group'
+import { ToggleGroup, ToggleGroupItem } from '@/registry/new-york-v4/ui/toggle-group'
 </script>
 
 <template>
-  <ToggleGroup variant="outline" type="multiple">
+  <ToggleGroup type="multiple" size="lg">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
       <Bold class="size-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
       <Italic class="size-4" />
     </ToggleGroupItem>
-    <ToggleGroupItem value="strikethrough" aria-label="Toggle strikethrough">
+    <ToggleGroupItem value="underline" aria-label="Toggle underline">
       <Underline class="size-4" />
     </ToggleGroupItem>
   </ToggleGroup>

--- a/apps/v4/components/demo/ToggleGroupSingleDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupSingleDemo.vue
@@ -6,13 +6,13 @@ import { ToggleGroup, ToggleGroupItem } from '@/registry/new-york-v4/ui/toggle-g
 <template>
   <ToggleGroup type="single">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
-      <Bold class="size-4" />
+      <Bold class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
-      <Italic class="size-4" />
+      <Italic class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="underline" aria-label="Toggle underline">
-      <Underline class="size-4" />
+      <Underline class="h-4 w-4" />
     </ToggleGroupItem>
   </ToggleGroup>
 </template>

--- a/apps/v4/components/demo/ToggleGroupSingleDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupSingleDemo.vue
@@ -1,21 +1,17 @@
 <script setup lang="ts">
 import { Bold, Italic, Underline } from 'lucide-vue-next'
-
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-} from '@/registry/new-york-v4/ui/toggle-group'
+import { ToggleGroup, ToggleGroupItem } from '@/registry/new-york-v4/ui/toggle-group'
 </script>
 
 <template>
-  <ToggleGroup variant="outline" type="multiple">
+  <ToggleGroup type="single">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
       <Bold class="size-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
       <Italic class="size-4" />
     </ToggleGroupItem>
-    <ToggleGroupItem value="strikethrough" aria-label="Toggle strikethrough">
+    <ToggleGroupItem value="underline" aria-label="Toggle underline">
       <Underline class="size-4" />
     </ToggleGroupItem>
   </ToggleGroup>

--- a/apps/v4/components/demo/ToggleGroupSmallDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupSmallDemo.vue
@@ -6,13 +6,13 @@ import { ToggleGroup, ToggleGroupItem } from '@/registry/new-york-v4/ui/toggle-g
 <template>
   <ToggleGroup type="single" size="sm">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
-      <Bold class="size-4" />
+      <Bold class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
-      <Italic class="size-4" />
+      <Italic class="h-4 w-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="underline" aria-label="Toggle underline">
-      <Underline class="size-4" />
+      <Underline class="h-4 w-4" />
     </ToggleGroupItem>
   </ToggleGroup>
 </template>

--- a/apps/v4/components/demo/ToggleGroupSmallDemo.vue
+++ b/apps/v4/components/demo/ToggleGroupSmallDemo.vue
@@ -1,21 +1,17 @@
 <script setup lang="ts">
 import { Bold, Italic, Underline } from 'lucide-vue-next'
-
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-} from '@/registry/new-york-v4/ui/toggle-group'
+import { ToggleGroup, ToggleGroupItem } from '@/registry/new-york-v4/ui/toggle-group'
 </script>
 
 <template>
-  <ToggleGroup variant="outline" type="multiple">
+  <ToggleGroup type="single" size="sm">
     <ToggleGroupItem value="bold" aria-label="Toggle bold">
       <Bold class="size-4" />
     </ToggleGroupItem>
     <ToggleGroupItem value="italic" aria-label="Toggle italic">
       <Italic class="size-4" />
     </ToggleGroupItem>
-    <ToggleGroupItem value="strikethrough" aria-label="Toggle strikethrough">
+    <ToggleGroupItem value="underline" aria-label="Toggle underline">
       <Underline class="size-4" />
     </ToggleGroupItem>
   </ToggleGroup>

--- a/apps/v4/content/docs/components/toggle-group.md
+++ b/apps/v4/content/docs/components/toggle-group.md
@@ -69,31 +69,59 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
 <template>
   <ToggleGroup type="multiple">
-    <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
-    <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
-    <ToggleGroupItem value="underline">Underline</ToggleGroupItem>
+    <ToggleGroupItem value="a">A</ToggleGroupItem>
+    <ToggleGroupItem value="b">B</ToggleGroupItem>
+    <ToggleGroupItem value="c">C</ToggleGroupItem>
   </ToggleGroup>
 </template>
 ```
 
 ## Examples
 
+### Default
+
+::component-preview
+---
+name: ToggleGroupDefaultDemo
+---
+::
+
+### Outline
+
+::component-preview
+---
+name: ToggleGroupDemo
+---
+::
+
 ### Single
 
-```vue showLineNumbers
-<ToggleGroup type="single">
-  <ToggleGroupItem value="left">Left</ToggleGroupItem>
-  <ToggleGroupItem value="center">Center</ToggleGroupItem>
-  <ToggleGroupItem value="right">Right</ToggleGroupItem>
-</ToggleGroup>
-```
+::component-preview
+---
+name: ToggleGroupSingleDemo
+---
+::
 
-### Multiple
+### Small
 
-```vue showLineNumbers
-<ToggleGroup type="multiple">
-  <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
-  <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
-  <ToggleGroupItem value="underline">Underline</ToggleGroupItem>
-</ToggleGroup>
-```
+::component-preview
+---
+name: ToggleGroupSmallDemo
+---
+::
+
+### Large
+
+::component-preview
+---
+name: ToggleGroupLargeDemo
+---
+::
+
+### Disabled
+
+::component-preview
+---
+name: ToggleGroupDisabledDemo
+---
+::


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

\-

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- added missing Toggle Group examples from shadcn/ui
- updated the documentation accordingly

Detail: Used the `size-4` class rather than `h-4 w-4` used in shadcn/ui, as it's functionally the same and cleaner syntax in my opinion.

### 📸 Screenshots (if appropriate)

Screenshot was made with a temporary fix for #1475 so it looks correct.

<img width="1920" height="1056" alt="Screenshot 2025-10-14 at 14 27 20" src="https://github.com/user-attachments/assets/887ab732-a51e-4065-ade1-96e704a8f69c" />

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
