### PR TITLE
style(InputGroup): remove transition animation

### DIFF
--- a/apps/www/src/registry/default/ui/input-group/InputGroup.vue
+++ b/apps/www/src/registry/default/ui/input-group/InputGroup.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
     data-slot="input-group"
     role="group"
     :class="cn(
-      'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none',
+      'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs outline-none',
       'h-10 min-w-0 has-[>textarea]:h-auto',
 
       // Variants based on alignment.

--- a/apps/www/src/registry/default/ui/input-group/InputGroup.vue
+++ b/apps/www/src/registry/default/ui/input-group/InputGroup.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
     data-slot="input-group"
     role="group"
     :class="cn(
-      'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs outline-none',
+      'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border outline-none',
       'h-10 min-w-0 has-[>textarea]:h-auto',
 
       // Variants based on alignment.

--- a/apps/www/src/registry/new-york/ui/input-group/InputGroup.vue
+++ b/apps/www/src/registry/new-york/ui/input-group/InputGroup.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
     data-slot="input-group"
     role="group"
     :class="cn(
-      'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none',
+      'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs outline-none',
       'h-9 min-w-0 has-[>textarea]:h-auto',
 
       // Variants based on alignment.

--- a/apps/www/src/registry/new-york/ui/input-group/InputGroup.vue
+++ b/apps/www/src/registry/new-york/ui/input-group/InputGroup.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
     data-slot="input-group"
     role="group"
     :class="cn(
-      'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs outline-none',
+      'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border outline-none',
       'h-9 min-w-0 has-[>textarea]:h-auto',
 
       // Variants based on alignment.


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The `input` / `textarea` component does not have a transition animation when it is focused, but the `input` / `textarea` within the `input-group` does have a transition animation. To maintain consistency, I removed the transition animation for the `input-group` when it is focused.

Input:

https://github.com/user-attachments/assets/e20efdec-f7e1-4452-bf13-22f0c2f252f1

Input in InputGroup

https://github.com/user-attachments/assets/eaa1294e-d6dd-47d2-8577-88592d5b98b1

### 📸 Screenshots (if appropriate)

now:

https://github.com/user-attachments/assets/337d308a-906d-42eb-9dda-2d75e7e2ab82



<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
