### PR TITLE
fix(docs): fix template structure in Field usage example

### DIFF
--- a/apps/www/src/content/docs/components/field.md
+++ b/apps/www/src/content/docs/components/field.md
@@ -15,6 +15,7 @@ npx shadcn-vue@latest add field
 ## Usage
 
 ```vue showLineNumbers
+<script setup lang="ts">
 import {
   Field,
   FieldContent,
@@ -34,22 +35,23 @@ import {
     <FieldLegend>Profile</FieldLegend>
     <FieldDescription>This appears on invoices and emails.</FieldDescription>
     <FieldGroup>
-        <Field>
+      <Field>
         <FieldLabel for="name">Full name</FieldLabel>
         <Input id="name" autoComplete="off" placeholder="Evil Rabbit" />
         <FieldDescription>This appears on invoices and emails.</FieldDescription>
-        </Field>
-        <Field>
+      </Field>
+      <Field>
         <FieldLabel for="username">Username</FieldLabel>
         <Input id="username" autoComplete="off" aria-invalid />
         <FieldError>Choose another username.</FieldError>
-        </Field>
-        <Field orientation="horizontal">
+      </Field>
+      <Field orientation="horizontal">
         <Switch id="newsletter" />
         <FieldLabel for="newsletter">Subscribe to the newsletter</FieldLabel>
-        </Field>
+      </Field>
     </FieldGroup>
- </FieldSet>
+  </FieldSet>
+</template>
 ```
 
 ## Anatomy


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)

### 📚 Description

- Fix template structure in the Field usage example to ensure valid Vue SFC syntax.
- Clean up indentation and code block formatting for better readability.

### 📸 Screenshots (if appropriate)

<img width="1038" height="757" alt="image" src="https://github.com/user-attachments/assets/b27ee31d-18c0-4d46-930a-54506c96ceb2" />

