### PR TITLE
fix: remove unnecessary TooltipArrow classes that overlap content

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/tooltip/TooltipContent.vue
+++ b/apps/v4/registry/new-york-v4/ui/tooltip/TooltipContent.vue
@@ -28,7 +28,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     >
       <slot />
 
-      <TooltipArrow class="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      <TooltipArrow class="fill-primary" />
     </TooltipContent>
   </TooltipPortal>
 </template>


### PR DESCRIPTION
Fixes #1306

## Summary
Fixed the issue where the TooltipArrow component overlaps text with descenders (letters like 'g', 'y', 'p', etc.) by removing unnecessary styling classes.

## Changes
- Removed all styling classes from `TooltipArrow` except `fill-primary`
- The arrow is already properly styled by reka-ui, so the additional classes were redundant and causing positioning issues

## Before
```vue
<TooltipArrow class="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
```

## After  
```vue
<TooltipArrow class="fill-primary" />
```

## Testing
The fix resolves the visual issue where text with descenders gets covered by the tooltip arrow, as reported in the original issue.

## Related
- This issue also exists in the original shadcn-ui: https://github.com/shadcn-ui/ui/issues/6933