### PR TITLE
fix(v4/docs): correct sidebar styles

### DIFF
--- a/apps/v4/components/DocsSidebar.vue
+++ b/apps/v4/components/DocsSidebar.vue
@@ -59,7 +59,7 @@ function isActive(href: string) {
 
 <template>
   <Sidebar
-    class="sticky top-[calc(var(--header-height)+1px)] z-30 hidden h-[calc(100svh-var(--header-height)-var(--footer-height))] bg-transparent lg:flex"
+    class="text-sidebar-foreground w-(--sidebar-width) flex-col sticky top-[calc(var(--header-height)+1px)] z-30 hidden h-[calc(100svh-var(--footer-height)+2rem)] bg-transparent lg:flex"
     collapsible="none"
   >
     <SidebarContent class="no-scrollbar px-2 pb-12">


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

\-

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR corrects a minor styling issue with the sidebar in the v4 docs, which were currently cut of above the bottom of the viewport and now stretch all the way to the bottom just like in https://ui.shadcn.com/docs.

Used the exact same tailwind styles from shadcn/ui.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

Before/after (there are now three more nav items visible because it's not being cut off):

<img width="293" height="1033" alt="Screenshot 2025-10-19 at 16 11 11" src="https://github.com/user-attachments/assets/8a4cbbce-06f4-4700-964f-9cf40c7aba39" />
<img width="297" height="1032" alt="Screenshot 2025-10-19 at 16 12 15" src="https://github.com/user-attachments/assets/411b09f2-caa0-40f7-9762-d7e4a17c961c" />

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
