### PR TITLE
fix(v4/docs): pass missing parameters to `handleNavigate` in MobileNav

### DIFF
--- a/apps/v4/components/MobileNav.vue
+++ b/apps/v4/components/MobileNav.vue
@@ -94,10 +94,10 @@ function handleNavigate(path: string) {
             Menu
           </div>
           <div class="flex flex-col gap-3">
-            <NuxtLink class="text-2xl font-medium" to="/" @click="handleNavigate">
+            <NuxtLink class="text-2xl font-medium" to="/" @click="handleNavigate('/')">
               Home
             </NuxtLink>
-            <NuxtLink v-for="(item, index) in items" :key="index" class="text-2xl font-medium" :to="item.href" @click="handleNavigate">
+            <NuxtLink v-for="(item, index) in items" :key="index" class="text-2xl font-medium" :to="item.href" @click="handleNavigate(item.href)">
               {{ item.label }}
             </NuxtLink>
           </div>
@@ -126,7 +126,7 @@ function handleNavigate(path: string) {
                 {{ group.title }}
               </div>
               <div class="flex flex-col gap-3">
-                <NuxtLink v-for="item in group.children" :key="item.path" class="text-2xl font-medium" :to="item.path" @click="handleNavigate">
+                <NuxtLink v-for="item in group.children" :key="item.path" class="text-2xl font-medium" :to="item.path" @click="handleNavigate(item.path)">
                   {{ item.title }}
                 </NuxtLink>
               </div>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

\-

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes an issue in the v4 docs MobileNav component where clicking nav items doesn't do anything because there are no parameters being passed to the `handleNavigate` function.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
