### PR TITLE
docs(v4): add missing raw markdown route

### DIFF
--- a/apps/v4/components/DocsCopyPage.vue
+++ b/apps/v4/components/DocsCopyPage.vue
@@ -26,6 +26,8 @@ const url = computed(() => {
   return isClient ? window.location.href : ''
 })
 
+const route = useRoute()
+
 function getPromptUrl(baseURL: string, url: string) {
   return `${baseURL}?q=${encodeURIComponent(
     `I’m looking at this shadcn-vue documentation: ${url}.
@@ -41,7 +43,7 @@ const menuItems = {
     h(
       'a',
       {
-        href: `${url}.md`,
+        href: `${window.location.origin}/raw${route.path}.md`,
         target: '_blank',
         rel: 'noopener noreferrer',
       },

--- a/apps/v4/server/routes/raw/[...slug].md.get.ts
+++ b/apps/v4/server/routes/raw/[...slug].md.get.ts
@@ -1,0 +1,16 @@
+import { queryCollection } from '@nuxt/content/server'
+
+export default defineEventHandler(async (event) => {
+  const params = getRouterParams(event)
+  const slug = `/${params['slug.md']}`
+  const contentSlug = slug.replace('.md', '')
+  const page = await queryCollection(event, 'content').path(contentSlug).first()
+
+  if (!page) {
+    throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+  }
+
+  setHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+
+  return page.rawbody
+})


### PR DESCRIPTION
### 🔗 Linked issue

\-

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a missing server route for the "View as Markdown" feature on docs pages that zernonia recently added to the v4 docs.

**Details**

Essentially, this does the same as "Copy Page", as it just serves the raw markdown source content (`page.rawbody`).

The route is prefixed with `/raw`, as I've not found another way to distinguish actual documentation pages from raw markdown pages just by the `.md` ending with Nuxt's file based routing.

**Things to consider**

With this implementation we're only serving the raw markdown source files, and not resolving MDC components which are inside of these files. As this feature is especially intended for giving context to LLMs, there is possibly important context missing that would be valuable to an LLM.

Example:

```md
::component-preview
---
name: ButtonDemo
description: A button
---
::
``` 

would provide way better information when resolved to a code block with the actual code of the demo:

```md
```vue
<script setup lang="ts">
import { ArrowUpIcon } from 'lucide-vue-next'
import { Button } from '@/registry/new-york-v4/ui/button'
</script>

<template>
  <div class="flex flex-wrap items-center gap-2 md:flex-row">
    <Button variant="outline">
      Button
    </Button>
    <Button variant="outline" size="icon" aria-label="Submit">
      <ArrowUpIcon />
    </Button>
  </div>
</template>
```

shadcn/ui doesn't have this issue: They're using [fumadocs](https://fumadocs.dev/) that does this under the hood, which therefore can't be applied to this project.

I've looked into how other Nuxt projects are approaching this, and I've looked into how [Nuxt UI](https://ui.nuxt.com/) does it. They're using the server route approach that I've adapted in this PR, and they've written a huge custom `transformMDC` function that's also entangled with their project structure, but does the important part of resolving components.

Sources: https://github.com/nuxt/ui/blob/v4/docs/server/utils/transformMDC.ts, https://github.com/nuxt/ui/blob/v4/docs/server/routes/raw/%5B...slug%5D.md.get.ts

So, what do you guys think about this? Should we add something like this to this project, are there better approaches, or are there just more important things right now?😅
Also, should I open another issue/discussion for this, or just address it in this PR?

### 📸 Screenshots (if appropriate)

\-

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
