### PR TITLE
feat: add customized theme css for tailwind v4

### DIFF
--- a/apps/www/.vitepress/theme/components/CustomizerCode.vue
+++ b/apps/www/.vitepress/theme/components/CustomizerCode.vue
@@ -25,9 +25,8 @@ async function copyCode() {
 
 <template>
   <div class="relative">
-    <pre class="max-h-[450px] overflow-x-auto rounded-lg border bg-zinc-950 !py-0 dark:bg-zinc-900">
-<code ref="codeRef" class="relative block rounded font-mono text-sm">
-<template v-if="tailwindVersion === 'v3'"><span class="line text-white">@layer base &#123;</span>
+    <pre class="max-h-[450px] overflow-x-auto rounded-lg border bg-zinc-950 dark:bg-zinc-900">
+<code ref="codeRef" class="relative block rounded font-mono text-sm"><template v-if="tailwindVersion === 'v3'"><span class="line text-white">@layer base &#123;</span>
   <span class="line text-white">:root &#123;</span>
   <span class="line text-white">&nbsp;&nbsp;--background: {{ activeTheme?.cssVars?.light?.background }};</span>
   <span class="line text-white">&nbsp;&nbsp;--foreground: {{ activeTheme?.cssVars?.light?.foreground }};</span>
@@ -75,8 +74,7 @@ async function copyCode() {
 <span class="line text-white">&nbsp;&nbsp;--border: hsl({{ activeTheme?.cssVars?.dark?.border }});</span>
 <span class="line text-white">&nbsp;&nbsp;--input: hsl({{ activeTheme?.cssVars?.dark?.input }});</span>
 <span class="line text-white">&nbsp;&nbsp;--ring: hsl({{ activeTheme?.cssVars?.dark?.ring }});</span>
-<span class="line text-white">&#125;</span></template>
-</code>
+<span class="line text-white">&#125;</span></template></code>
 </pre>
     <Button size="sm" class="absolute right-4 top-4 bg-muted text-muted-foreground hover:bg-muted hover:text-muted-foreground" @click="copyCode">
       <CheckIcon v-if="copied" class="mr-2 h-4 w-4" />

--- a/apps/www/.vitepress/theme/components/CustomizerCode.vue
+++ b/apps/www/.vitepress/theme/components/CustomizerCode.vue
@@ -7,6 +7,10 @@ import { Button } from '@/registry/new-york/ui/button'
 import { baseColors } from '@/registry/registry-base-colors'
 import { useConfigStore } from '@/stores/config'
 
+const { tailwindVersion = 'v3' } = defineProps<{
+  tailwindVersion?: 'v3' | 'v4'
+}>()
+
 const { theme, config } = useConfigStore()
 
 const activeTheme = computed(() => baseColors.find(i => i.name === theme.value))
@@ -23,7 +27,7 @@ async function copyCode() {
   <div class="relative">
     <pre class="max-h-[450px] overflow-x-auto rounded-lg border bg-zinc-950 !py-0 dark:bg-zinc-900">
 <code ref="codeRef" class="relative block rounded font-mono text-sm">
-<span class="line text-white">@layer base &#123;</span>
+<template v-if="tailwindVersion === 'v3'"><span class="line text-white">@layer base &#123;</span>
   <span class="line text-white">:root &#123;</span>
   <span class="line text-white">&nbsp;&nbsp;--background: {{ activeTheme?.cssVars?.light?.background }};</span>
   <span class="line text-white">&nbsp;&nbsp;--foreground: {{ activeTheme?.cssVars?.light?.foreground }};</span>
@@ -48,7 +52,30 @@ async function copyCode() {
   <span class="line text-white">&nbsp;&nbsp;--input:{{ activeTheme?.cssVars?.dark?.input }};</span>
   <span class="line text-white">&nbsp;&nbsp;--ring:{{ activeTheme?.cssVars?.dark?.ring }};</span>
   <span class="line text-white">&#125;</span>
+<span class="line text-white">&#125;</span></template><template v-else-if="tailwindVersion === 'v4'"><span class="line text-white">:root &#123;</span>
+<span class="line text-white">&nbsp;&nbsp;--background: hsl({{ activeTheme?.cssVars?.light?.background }});</span>
+<span class="line text-white">&nbsp;&nbsp;--foreground: hsl({{ activeTheme?.cssVars?.light?.foreground }});</span>
+<template v-for="prefix in (['card', 'popover', 'primary', 'secondary', 'muted', 'accent', 'destructive'] as const)" :key="prefix">
+  <span class="line text-white">--{{ prefix }}: hsl({{ activeTheme?.cssVars?.light?.[prefix] }});</span>
+  <span class="line text-white">--{{ prefix }}-foreground: hsl({{ activeTheme?.cssVars?.light?.[ `${prefix}-foreground`] }});</span>
+</template>
+<span class="line text-white">&nbsp;&nbsp;--border: hsl({{ activeTheme?.cssVars?.light?.border }});</span>
+<span class="line text-white">&nbsp;&nbsp;--input: hsl({{ activeTheme?.cssVars?.light?.input }});</span>
+<span class="line text-white">&nbsp;&nbsp;--ring: hsl({{ activeTheme?.cssVars?.light?.ring }});</span>
+<span class="line text-white">&nbsp;&nbsp;--radius: {{ config.radius }}rem;</span>
 <span class="line text-white">&#125;</span>
+<span class="line text-white" />
+<span class="line text-white">.dark &#123;</span>
+<span class="line text-white">&nbsp;&nbsp;--background: hsl({{ activeTheme?.cssVars?.dark?.background }});</span>
+<span class="line text-white">&nbsp;&nbsp;--foreground: hsl({{ activeTheme?.cssVars?.dark?.foreground }});</span>
+<template v-for="prefix in (['card', 'popover', 'primary', 'secondary', 'muted', 'accent', 'destructive'] as const)" :key="prefix">
+  <span class="line text-white">--{{ prefix }}: hsl({{ activeTheme?.cssVars?.dark?.[ prefix] }});</span>
+  <span class="line text-white">--{{ prefix }}-foreground: hsl({{ activeTheme?.cssVars?.dark?.[ `${prefix}-foreground`] }});</span>
+</template>
+<span class="line text-white">&nbsp;&nbsp;--border: hsl({{ activeTheme?.cssVars?.dark?.border }});</span>
+<span class="line text-white">&nbsp;&nbsp;--input: hsl({{ activeTheme?.cssVars?.dark?.input }});</span>
+<span class="line text-white">&nbsp;&nbsp;--ring: hsl({{ activeTheme?.cssVars?.dark?.ring }});</span>
+<span class="line text-white">&#125;</span></template>
 </code>
 </pre>
     <Button size="sm" class="absolute right-4 top-4 bg-muted text-muted-foreground hover:bg-muted hover:text-muted-foreground" @click="copyCode">

--- a/apps/www/.vitepress/theme/components/CustomizerCode.vue
+++ b/apps/www/.vitepress/theme/components/CustomizerCode.vue
@@ -34,22 +34,22 @@ async function copyCode() {
     <span class="line text-white">--{{ prefix }}: {{ activeTheme?.cssVars?.light?.[prefix] }};</span>
     <span class="line text-white">--{{ prefix }}-foreground: {{ activeTheme?.cssVars?.light?.[ `${prefix}-foreground`] }};</span>
   </template>
-  <span class="line text-white">&nbsp;&nbsp;--border:{{ activeTheme?.cssVars?.light?.border }};</span>
-  <span class="line text-white">&nbsp;&nbsp;--input:{{ activeTheme?.cssVars?.light?.input }};</span>
-  <span class="line text-white">&nbsp;&nbsp;--ring:{{ activeTheme?.cssVars?.light?.ring }};</span>
+  <span class="line text-white">&nbsp;&nbsp;--border: {{ activeTheme?.cssVars?.light?.border }};</span>
+  <span class="line text-white">&nbsp;&nbsp;--input: {{ activeTheme?.cssVars?.light?.input }};</span>
+  <span class="line text-white">&nbsp;&nbsp;--ring: {{ activeTheme?.cssVars?.light?.ring }};</span>
   <span class="line text-white">&nbsp;&nbsp;--radius: {{ config.radius }}rem;</span>
   <span class="line text-white">&#125;</span>
   <span class="line text-white">&nbsp;</span>
   <span class="line text-white">.dark &#123;</span>
-  <span class="line text-white">&nbsp;&nbsp;--background:{{ activeTheme?.cssVars?.dark?.background }};</span>
-  <span class="line text-white">&nbsp;&nbsp;--foreground:{{ activeTheme?.cssVars?.dark?.foreground }};</span>
+  <span class="line text-white">&nbsp;&nbsp;--background: {{ activeTheme?.cssVars?.dark?.background }};</span>
+  <span class="line text-white">&nbsp;&nbsp;--foreground: {{ activeTheme?.cssVars?.dark?.foreground }};</span>
   <template v-for="prefix in (['card', 'popover', 'primary', 'secondary', 'muted', 'accent', 'destructive'] as const)" :key="prefix">
-    <span class="line text-white">--{{ prefix }}:{{ activeTheme?.cssVars?.dark?.[ prefix] }};</span>
-    <span class="line text-white">--{{ prefix }}-foreground:{{ activeTheme?.cssVars?.dark?.[ `${prefix}-foreground`] }};</span>
+    <span class="line text-white">--{{ prefix }}: {{ activeTheme?.cssVars?.dark?.[ prefix] }};</span>
+    <span class="line text-white">--{{ prefix }}-foreground: {{ activeTheme?.cssVars?.dark?.[ `${prefix}-foreground`] }};</span>
   </template>
-  <span class="line text-white">&nbsp;&nbsp;--border:{{ activeTheme?.cssVars?.dark?.border }};</span>
-  <span class="line text-white">&nbsp;&nbsp;--input:{{ activeTheme?.cssVars?.dark?.input }};</span>
-  <span class="line text-white">&nbsp;&nbsp;--ring:{{ activeTheme?.cssVars?.dark?.ring }};</span>
+  <span class="line text-white">&nbsp;&nbsp;--border: {{ activeTheme?.cssVars?.dark?.border }};</span>
+  <span class="line text-white">&nbsp;&nbsp;--input: {{ activeTheme?.cssVars?.dark?.input }};</span>
+  <span class="line text-white">&nbsp;&nbsp;--ring: {{ activeTheme?.cssVars?.dark?.ring }};</span>
   <span class="line text-white">&#125;</span>
 <span class="line text-white">&#125;</span></template><template v-else-if="tailwindVersion === 'v4'"><span class="line text-white">:root &#123;</span>
 <span class="line text-white">&nbsp;&nbsp;--background: hsl({{ activeTheme?.cssVars?.light?.background }});</span>

--- a/apps/www/.vitepress/theme/layout/ThemingLayout.vue
+++ b/apps/www/.vitepress/theme/layout/ThemingLayout.vue
@@ -5,6 +5,7 @@ import { Button } from '@/registry/new-york/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/registry/new-york/ui/dialog'
 import { Drawer, DrawerContent, DrawerTrigger } from '@/registry/new-york/ui/drawer'
 import { Popover, PopoverContent, PopoverTrigger } from '@/registry/new-york/ui/popover'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/registry/new-york/ui/tabs'
 import { useConfigStore } from '@/stores/config'
 import Announcement from '../components/Announcement.vue'
 import CustomizerCode from '../components/CustomizerCode.vue'
@@ -105,7 +106,22 @@ watch(radius, (radius) => {
                 Copy and paste the following code into your CSS file.
               </DialogDescription>
             </DialogHeader>
-            <CustomizerCode />
+            <Tabs default-value="v3">
+              <TabsList>
+                <TabsTrigger value="v3">
+                  Tailwind v3
+                </TabsTrigger>
+                <TabsTrigger value="v4">
+                  Tailwind v4
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="v3">
+                <CustomizerCode tailwind-version="v3" />
+              </TabsContent>
+              <TabsContent value="v4">
+                <CustomizerCode tailwind-version="v4" />
+              </TabsContent>
+            </Tabs>
           </DialogContent>
         </Dialog>
       </PageAction>


### PR DESCRIPTION
### 🔗 Linked issue

#1525

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #1525 

This PR adds an option for tailwind v4 compatible output to the customized theme css. Users can choose between tailwind v3 and v4, with v3 staying the default for now.

I reused the baseColors (v3) for the v4 output, as the baseColorsV4 does not include variables for the colored themes yet (red, violet, blue, green, ...). I have converted the colored themes to oklch with a small script and added them to baseColorsV4 in [another branch](https://github.com/Scalamando/shadcn-vue/tree/oklch-colors) and could open an PR if you're interested.

I've also taken the liberty to make the spacings between property and value consistent and trimmed empty lines at the top and bottom of the generated code block. If hope that's okay!

### 📸 Screenshots

<div style="display: flex; gap: 0.5rem">
<img width="718" height="679" alt="image" src="https://github.com/user-attachments/assets/57bad4e7-2d77-4b6d-b209-9bad4722ae92" style="min-width: 300px" />
<img width="716" height="681" alt="image" src="https://github.com/user-attachments/assets/33492519-5f5c-487c-8285-b5e0fdeb8a25" style="min-width: 300px" />
</div>


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
