### PR TITLE
fix(docs): correct user-facing imports in component demos

### DIFF
--- a/apps/v4/components/ComponentSource.vue
+++ b/apps/v4/components/ComponentSource.vue
@@ -16,7 +16,39 @@ const props = withDefaults(defineProps<{
   collapsible: true,
 })
 
-const code = (await import(`@/components/demo/${props.name}.${props.language}?raw`)).default
+/**
+ * @see apps/v4/lib/registry.ts
+ */
+function fixImport(content: string) {
+  // eslint-disable-next-line regexp/no-super-linear-backtracking
+  const regex = /@\/(.+?)\/((?:.*?\/)?(?:components|ui|hooks|lib))\/([\w-]+)/g
+
+  const replacement = (
+    match: string,
+    path: string,
+    type: string,
+    component: string,
+  ) => {
+    if (type.endsWith('components')) {
+      return `@/components/${component}`
+    }
+    else if (type.endsWith('ui')) {
+      return `@/components/ui/${component}`
+    }
+    else if (type.endsWith('hooks')) {
+      return `@/hooks/${component}`
+    }
+    else if (type.endsWith('lib')) {
+      return `@/lib/${component}`
+    }
+
+    return match
+  }
+
+  return content.replace(regex, replacement)
+}
+
+const code = fixImport((await import(`@/components/demo/${props.name}.${props.language}?raw`)).default)
 </script>
 
 <template>

--- a/apps/v4/components/ComponentSource.vue
+++ b/apps/v4/components/ComponentSource.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
+import { fixImport } from '~/lib/registry-utils'
 import { cn } from '~/lib/utils'
 import { getIconForLanguageExtension } from './Icons'
 
@@ -15,38 +16,6 @@ const props = withDefaults(defineProps<{
   language: 'vue',
   collapsible: true,
 })
-
-/**
- * @see apps/v4/lib/registry.ts
- */
-function fixImport(content: string) {
-  // eslint-disable-next-line regexp/no-super-linear-backtracking
-  const regex = /@\/(.+?)\/((?:.*?\/)?(?:components|ui|hooks|lib))\/([\w-]+)/g
-
-  const replacement = (
-    match: string,
-    path: string,
-    type: string,
-    component: string,
-  ) => {
-    if (type.endsWith('components')) {
-      return `@/components/${component}`
-    }
-    else if (type.endsWith('ui')) {
-      return `@/components/ui/${component}`
-    }
-    else if (type.endsWith('hooks')) {
-      return `@/hooks/${component}`
-    }
-    else if (type.endsWith('lib')) {
-      return `@/lib/${component}`
-    }
-
-    return match
-  }
-
-  return content.replace(regex, replacement)
-}
 
 const code = fixImport((await import(`@/components/demo/${props.name}.${props.language}?raw`)).default)
 </script>

--- a/apps/v4/lib/registry-utils.ts
+++ b/apps/v4/lib/registry-utils.ts
@@ -1,0 +1,28 @@
+export function fixImport(content: string) {
+  // eslint-disable-next-line regexp/no-super-linear-backtracking
+  const regex = /@\/(.+?)\/((?:.*?\/)?(?:components|ui|composables|lib))\/([\w-]+)/g
+
+  const replacement = (
+    match: string,
+    path: string,
+    type: string,
+    component: string,
+  ) => {
+    if (type.endsWith('components')) {
+      return `@/components/${component}`
+    }
+    else if (type.endsWith('ui')) {
+      return `@/components/ui/${component}`
+    }
+    else if (type.endsWith('composables')) {
+      return `@/composables/${component}`
+    }
+    else if (type.endsWith('lib')) {
+      return `@/lib/${component}`
+    }
+
+    return match
+  }
+
+  return content.replace(regex, replacement)
+}

--- a/apps/v4/lib/registry.ts
+++ b/apps/v4/lib/registry.ts
@@ -8,6 +8,7 @@ import path from 'node:path'
 
 import { registryItemSchema } from 'shadcn-vue/schema'
 import { blockMeta } from '@/registry/registry-block-meta'
+import { fixImport } from '~/lib/registry-utils'
 import { Index } from '~/registry/__index__'
 
 export function getRegistryComponent(name: string) {
@@ -136,35 +137,6 @@ function fixFilePaths(files: z.infer<typeof registryItemSchema>['files']) {
       target: getFileTarget(file),
     }
   })
-}
-
-export function fixImport(content: string) {
-  // eslint-disable-next-line regexp/no-super-linear-backtracking
-  const regex = /@\/(.+?)\/((?:.*?\/)?(?:components|ui|hooks|lib))\/([\w-]+)/g
-
-  const replacement = (
-    match: string,
-    path: string,
-    type: string,
-    component: string,
-  ) => {
-    if (type.endsWith('components')) {
-      return `@/components/${component}`
-    }
-    else if (type.endsWith('ui')) {
-      return `@/components/ui/${component}`
-    }
-    else if (type.endsWith('hooks')) {
-      return `@/hooks/${component}`
-    }
-    else if (type.endsWith('lib')) {
-      return `@/lib/${component}`
-    }
-
-    return match
-  }
-
-  return content.replace(regex, replacement)
 }
 
 export interface FileTree {


### PR DESCRIPTION
### 🔗 Linked issue

\-

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes the internal `@/registry/new-york-v4/...` imports currently being displayed in component demos on the website, which are replaced by the default `@/components/ui/...` import alias. This makes it easier for users to copy-paste code examples without having to manually fix the imports :)

### Details

I copied the `fixImport` function from `~/lib/registry.ts` into the `ComponentSource` component itself, because importing it from `~/lib/registry.ts` caused a 500 error by Vite, related to the `node:fs` import in `registry.ts`:

<img width="940" height="489" alt="Screenshot 2025-11-15 at 10 54 24" src="https://github.com/user-attachments/assets/9e477dea-1113-417a-a5c2-2d355a65c275" />

It might be better here to fix the underlying issue itself, so `registry.ts` can be used in client-side components too. What do you think about this?

### 📸 Screenshots (if appropriate)

Before:
<img width="775" height="470" alt="Screenshot 2025-11-15 at 11 20 13" src="https://github.com/user-attachments/assets/90e6cae2-9cd8-4883-8223-5ad17fa20efc" />

After:
<img width="772" height="449" alt="Screenshot 2025-11-15 at 11 19 58" src="https://github.com/user-attachments/assets/9c69511f-69dc-4fa4-81a8-90d267563891" />


<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
