### PR TITLE
fix(docs): display section items in MobileNavigation, update styles

### DIFF
--- a/apps/v4/components/MobileNav.vue
+++ b/apps/v4/components/MobileNav.vue
@@ -120,14 +120,15 @@ function handleNavigate(path: string) {
           </div>
         </div>
         <div class="flex flex-col gap-8">
-          <template v-for="(group, index) in tree" :key="index">
+          <template v-for="(group, index) in tree[0]?.children" :key="index">
             <div class="flex flex-col gap-4">
               <div class="text-muted-foreground text-sm font-medium">
                 {{ group.title }}
               </div>
               <div class="flex flex-col gap-3">
-                <NuxtLink v-for="item in group.children" :key="item.path" class="text-2xl font-medium" :to="item.path" @click="handleNavigate(item.path)">
+                <NuxtLink v-for="item in group.children" :key="item.path" class="flex items-center gap-2 text-2xl font-medium" :to="item.path" @click="handleNavigate(item.path)">
                   {{ item.title }}
+                  <span v-if="item.new" class="flex size-2 rounded-full bg-green-500" />
                 </NuxtLink>
               </div>
             </div>

--- a/apps/v4/pages/docs/[...slug].vue
+++ b/apps/v4/pages/docs/[...slug].vue
@@ -52,7 +52,7 @@ useSeoMeta({
                     v-if="neighbours?.[0]"
                     variant="secondary"
                     size="icon"
-                    class="extend-touch-target size-8 shadow-none md:size-7"
+                    class="extend-touch-target ml-auto size-8 shadow-none md:size-7"
                     as-child
                   >
                     <NuxtLink :to="neighbours[0].path">


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

\-

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- fixed MobileNav to display the actual sections with their items
- added the "New" indicator to mobile navigation items
- added left padding to the previous button on the bottom navigation on mobile (like shadcn/ui docs)

### 📸 Screenshots (if appropriate)

Before (duplicated sections instead of the actual sections with their items):
<img width="397" height="768" alt="Screenshot 2025-11-17 at 13 38 58" src="https://github.com/user-attachments/assets/a6ec61f2-ad39-417c-bf80-0d3858fff0fc" />

After:
<img width="398" height="765" alt="Screenshot 2025-11-17 at 13 38 40" src="https://github.com/user-attachments/assets/24b4de69-a9da-4497-a429-0cbdbeca5242" />

Before (Previous/Next buttons stuck to the left):
<img width="387" height="60" alt="Screenshot 2025-11-17 at 13 40 36" src="https://github.com/user-attachments/assets/62964838-b2b0-4e04-9a1a-5176aea70e49" />

After:
<img width="395" height="59" alt="Screenshot 2025-11-17 at 13 40 49" src="https://github.com/user-attachments/assets/2e889a9f-42fa-4ea5-96ba-80eef89315de" />


<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
