### PR TITLE
chore(deps): hoist tsx to root and manage via catalog

### DIFF
--- a/deprecated/www/package.json
+++ b/deprecated/www/package.json
@@ -72,7 +72,6 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^3.4.18",
     "tinyglobby": "catalog:",
-    "tsx": "^4.20.6",
     "typescript": "catalog:",
     "unplugin-icons": "^22.5.0",
     "vitepress": "^1.6.4",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint-staged": "^16.2.6",
     "simple-git-hooks": "^2.13.1",
     "taze": "^19.9.0",
+    "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     tinyglobby:
       specifier: ^0.2.15
       version: 0.2.15
+    tsx:
+      specifier: ^4.20.6
+      version: 4.20.6
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -105,6 +108,9 @@ importers:
       taze:
         specifier: ^19.9.0
         version: 19.9.0
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -18527,7 +18533,6 @@ snapshots:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   tw-animate-css@1.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
   pathe: ^2.0.3
   reka-ui: ^2.6.0
   tinyglobby: ^0.2.15
+  tsx: ^4.20.6
   typescript: ^5.9.3
   vaul-vue: ^0.4.1
   vee-validate: ^4.15.1


### PR DESCRIPTION
If `tsx` is not elevated to the root directory's `package.json`, `tsx` will not be installed in `v4`, causing an error when executing `registry:build`.