### PR TITLE
chore: use exec instead of execFile for prettier to support Wi…

### DIFF
--- a/apps/v4/scripts/build-registry.ts
+++ b/apps/v4/scripts/build-registry.ts
@@ -135,9 +135,8 @@ async function buildRegistryJsonFile() {
 
   const registryJsonPath = path.join(outputDir, 'registry.json')
   await fs.writeFile(registryJsonPath, JSON.stringify(fixedRegistry, null, 2))
-  // 使用 exec 替代 execFile，通过 npx 调用本地安装的 prettier
   await new Promise<void>((resolve, reject) => {
-    exec(`npx prettier --write "${registryJsonPath}"`, (error) => {
+    exec(`pnpm exec prettier --write "${registryJsonPath}"`, (error) => {
       if (error) {
         reject(error)
       }


### PR DESCRIPTION
@sadeghbarati Sorry, I accidentally inserted a Chinese comment earlier.

Since my environment is Windows, when executing the code `https://github.com/jevin98/shadcn-vue/blob/dev/apps/v4/scripts/build-registry.ts#L140`, I used `execFile` to run `prettier`. However, Windows doesn't seem to support `execFile`. Given that my project currently uses pnpm, I've changed it to use `pnpm exec` to run `prettier`.