### PR TITLE
chore(typo): reflect Vue support in blocks homepage

### DIFF
--- a/apps/v4/pages/blocks.vue
+++ b/apps/v4/pages/blocks.vue
@@ -3,7 +3,7 @@ import { Button } from '@/registry/new-york-v4/ui/button'
 
 const title = 'Building Blocks for the Web'
 const description
-  = 'Clean, modern building blocks. Copy and paste into your apps. Works with all React frameworks. Open Source. Free forever.'
+  = 'Clean, modern building blocks. Copy and paste into your apps. Works with all Vue frameworks. Open Source. Free forever.'
 
 useSeoMeta({
   title,


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Blocks homepage is advertising React support instead of Vue