### PR TITLE
Update overwrite confirmation message with component name

### DIFF
--- a/packages/cli/src/utils/updaters/update-files.ts
+++ b/packages/cli/src/utils/updaters/update-files.ts
@@ -155,7 +155,7 @@ export async function updateFiles(
         type: 'confirm',
         name: 'overwrite',
         message: `The file ${highlighter.info(
-          fileName,
+          path.relative(config.resolvedPaths.ui, filePath),
         )} already exists. Would you like to overwrite?`,
         initial: false,
       })


### PR DESCRIPTION
### ❓ Type of change

### 📚 Description
In cli when updating several components, the prompt for overwriting the index.ts  component is unknown.

<img width="516" height="56" alt="image" src="https://github.com/user-attachments/assets/f5fed340-a4c7-4313-9997-058ba2204851" />

Replacing with:

<img width="626" height="56" alt="image" src="https://github.com/user-attachments/assets/e6b6271f-7b46-4229-85b5-4596e2f4a799" />

