### PR TITLE
fix(cli): preserve intermediate directories when resolving nested file paths

### DIFF
--- a/packages/cli/src/utils/updaters/update-files.ts
+++ b/packages/cli/src/utils/updaters/update-files.ts
@@ -357,7 +357,7 @@ export function resolveFilePath(
 
   const targetDir = resolveFileTargetDirectory(file, config)
 
-  const relativePath = resolveNestedFilePath(file.path, options.commonRoot)
+  const relativePath = resolveNestedFilePath(file.path, options.commonRoot, config)
   return path.join(targetDir!, relativePath)
 }
 
@@ -419,11 +419,28 @@ export function findCommonRoot(paths: string[], needle: string): string {
 export function resolveNestedFilePath(
   filePath: string,
   commonRoot: string,
+  config: Config,
 ): string {
   // Normalize paths by removing leading/trailing slashes
   const normalizedFilePath = filePath.replace(/^\/|\/$/g, '')
   const normalizedCommonRoot = commonRoot.replace(/^\/|\/$/g, '')
 
+  // Get component alias without @ prefix and normalize
+  const componentAlias = config.aliases.components.replace(/^@\//, '').replace(/^\/|\/$/g, '')
+
+  // Check if the common root contains the component alias
+  if (normalizedCommonRoot.includes(componentAlias)) {
+    // Find where the component alias ends in the file path
+    const aliasEndIndex = normalizedFilePath.indexOf(componentAlias) + componentAlias.length
+
+    // Return everything after the alias (skip the leading slash if present)
+    // Example: "components/ai-elements/artifact/Artifact.vue" -> "ai-elements/artifact/Artifact.vue"
+    // Example: "src/ui/design-system/button/Button.vue" -> "design-system/button/Button.vue"
+    return normalizedFilePath.substring(aliasEndIndex).replace(/^\//, '')
+  }
+
+  // Fallback to original logic for non-component paths
+  // Example: "registry/new-york-v4/ui/button/Button.vue" -> "button/Button.vue"
   const lastCommonRootSegment = normalizedCommonRoot.split('/').pop()
 
   // normalizedFilePath: registry/new-york-v4/ui/button/Button.vue


### PR DESCRIPTION
### 🔗 Linked issue

resolve #1605

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes component installation paths for custom registries with additional path levels. Previously, only the last segment of the common root was preserved, causing intermediate directories to be lost.

Example:
- Before: components/ai-elements/artifact/Artifact.vue → artifact/Artifact.vue
- After: components/ai-elements/artifact/Artifact.vue → ai-elements/artifact/Artifact.vue

The function now uses the component alias from config to correctly resolve paths for any custom registry structure, not just the default "components" directory.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
