### PR TITLE
docs: add responsive modal example

### DIFF
--- a/apps/v4/components/demo/DialogResponsive.vue
+++ b/apps/v4/components/demo/DialogResponsive.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { useMediaQuery } from '@vueuse/core'
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/registry/new-york-v4/ui/dialog'
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/registry/new-york-v4/ui/drawer'
+import { Input } from '@/registry/new-york-v4/ui/input'
+import { Label } from '@/registry/new-york-v4/ui/label'
+
+const isDesktop = useMediaQuery('(min-width: 640px)')
+
+const Modal = computed(() => ({
+  Root: isDesktop.value ? Dialog : Drawer,
+  Trigger: isDesktop.value ? DialogTrigger : DrawerTrigger,
+  Content: isDesktop.value ? DialogContent : DrawerContent,
+  Header: isDesktop.value ? DialogHeader : DrawerHeader,
+  Title: isDesktop.value ? DialogTitle : DrawerTitle,
+  Description: isDesktop.value ? DialogDescription : DrawerDescription,
+  Footer: isDesktop.value ? DialogFooter : DrawerFooter,
+  Close: isDesktop.value ? DialogClose : DrawerClose,
+}))
+</script>
+
+<template>
+  <component :is="Modal.Root">
+    <component :is="Modal.Trigger" as-child>
+      <Button variant="outline">
+        Open Dialog
+      </Button>
+    </component>
+    <component
+      :is="Modal.Content"
+      class="sm:max-w-md" :class="[
+        { 'px-2 pb-8 *:px-4': !isDesktop },
+      ]"
+    >
+      <component :is="Modal.Header">
+        <component :is="Modal.Title">
+          Share Link
+        </component>
+        <component :is="Modal.Description">
+          Anyone who has this link will be able to view this.
+        </component>
+      </component>
+
+      <div class="flex items-center gap-2">
+        <div class="grid flex-1 gap-2">
+          <Label for="link" class="sr-only">
+            Link
+          </Label>
+          <Input
+            id="link"
+            default-value="https://www.shadcn-vue.com/docs/installation"
+            read-only
+          />
+        </div>
+      </div>
+
+      <component :is="Modal.Footer" class="pt-4">
+        <component :is="Modal.Close" as-child>
+          <Button variant="outline">
+            Close
+          </Button>
+        </component>
+      </component>
+    </component>
+  </component>
+</template>

--- a/apps/v4/components/demo/index.ts
+++ b/apps/v4/components/demo/index.ts
@@ -44,6 +44,7 @@ export { default as CollapsibleDemo } from './CollapsibleDemo.vue'
 export { default as ComboboxDemo } from './ComboboxDemo.vue'
 // Dialog demos
 export { default as DialogDemo } from './DialogDemo.vue'
+export { default as DialogResponsive } from './DialogResponsive.vue'
 
 // Hover Card demos
 export { default as HoverCardDemo } from './HoverCardDemo.vue'

--- a/apps/v4/content/docs/components/dialog.md
+++ b/apps/v4/content/docs/components/dialog.md
@@ -111,6 +111,16 @@ name: DialogForm
 ---
 ::
 
+### Responsive Modal (Dialog & Drawer)
+
+Use a `Drawer` component for smaller viewport sizes and a `Dialog` component otherwise. This can be further made reusable by using slots for various parts of the modal.
+
+::component-preview
+---
+name: DialogResponsive
+---
+::
+
 ## Notes
 
 To use the `Dialog` component from within a `Context Menu` or `Dropdown Menu`, you must encase the `Context Menu` or

--- a/apps/v4/content/docs/components/drawer.md
+++ b/apps/v4/content/docs/components/drawer.md
@@ -98,3 +98,15 @@ import {
   </Drawer>
 </template>
 ```
+
+## Example
+
+### Responsive Modal (Dialog & Drawer)
+
+Use a `Drawer` component for smaller viewport sizes and a `Dialog` component otherwise. This can be further made reusable by using slots for various parts of the modal.
+
+::component-preview
+---
+name: DialogResponsive
+---
+::


### PR DESCRIPTION
### 🔗 Linked issue

N/A - Documentation Update

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR doesn't resolve any particular issue. It adds an additional example to the `Dialog` and `Drawer` component docs. More specifically, it adds an example implementation of a responsive and user-friendly modal using both `Dialog` and `Drawer`.

### 📸 Screenshots

| Desktop | Mobile |
| ------- | ------ |
| <img width="1280" height="800" alt="desktop" src="https://github.com/user-attachments/assets/8fde14a4-a731-4e95-bcc0-0edeff429245" /> | <img width="375" height="667" alt="mobile" src="https://github.com/user-attachments/assets/71c3ba94-d66c-4ab3-97a7-2ded1c932c1e" /> |


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
