### PR TITLE
fix(cli): resolve nested paths for all aliases, not just components

### DIFF
--- a/packages/cli/src/utils/updaters/update-files.ts
+++ b/packages/cli/src/utils/updaters/update-files.ts
@@ -425,21 +425,26 @@ export function resolveNestedFilePath(
   const normalizedFilePath = filePath.replace(/^\/|\/$/g, '')
   const normalizedCommonRoot = commonRoot.replace(/^\/|\/$/g, '')
 
-  // Get component alias without @ prefix and normalize
-  const componentAlias = config.aliases.components.replace(/^@\//, '').replace(/^\/|\/$/g, '')
+  // Get all aliases without @ prefix and normalize
+  const aliases = Object.values(config.aliases)
+    .map(alias => alias.replace(/^@\//, '').replace(/^\/|\/$/g, ''))
+    .sort((a, b) => b.length - a.length) // Sort by length descending to match most specific first
 
-  // Check if the common root contains the component alias
-  if (normalizedCommonRoot.includes(componentAlias)) {
-    // Find where the component alias ends in the file path
-    const aliasEndIndex = normalizedFilePath.indexOf(componentAlias) + componentAlias.length
+  // Check if the common root contains any of the aliases
+  for (const alias of aliases) {
+    if (normalizedCommonRoot.includes(alias)) {
+      // Find where the alias ends in the file path
+      const aliasEndIndex = normalizedFilePath.indexOf(alias) + alias.length
 
-    // Return everything after the alias (skip the leading slash if present)
-    // Example: "components/ai-elements/artifact/Artifact.vue" -> "ai-elements/artifact/Artifact.vue"
-    // Example: "src/ui/design-system/button/Button.vue" -> "design-system/button/Button.vue"
-    return normalizedFilePath.substring(aliasEndIndex).replace(/^\//, '')
+      // Return everything after the alias (skip the leading slash if present)
+      // Example: "components/ai-elements/artifact/Artifact.vue" -> "ai-elements/artifact/Artifact.vue"
+      // Example: "lib/utils/cn.ts" -> "utils/cn.ts"
+      // Example: "composables/useCounter.ts" -> "useCounter.ts"
+      return normalizedFilePath.substring(aliasEndIndex).replace(/^\//, '')
+    }
   }
 
-  // Fallback to original logic for non-component paths
+  // Fallback to original logic for non-aliased paths
   // Example: "registry/new-york-v4/ui/button/Button.vue" -> "button/Button.vue"
   const lastCommonRootSegment = normalizedCommonRoot.split('/').pop()
 


### PR DESCRIPTION
### 🔗 Linked issue

Close #1614

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes nested file path resolution to work with all configured aliases 
(components, lib, composables, etc.), preventing duplicate directory 
segments during installation.

Previously, the function only checked the components alias, causing 
files from other aliases to be resolved incorrectly:
- lib/utils/cn.ts → lib/cn.ts (installed to src/lib/lib/cn.ts)
- composables/useCounter.ts → composables/useCounter.ts (installed to src/composables/composables/useCounter.ts)

Now processes all aliases and matches the most specific one first:
- lib/utils/cn.ts → utils/cn.ts (installs to src/lib/utils/cn.ts)
- composables/useCounter.ts → useCounter.ts (installs to src/composables/useCounter.ts)
- components/ai-elements/artifact/Artifact.vue → ai-elements/artifact/Artifact.vue

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
