### PR TITLE
feat(form): add flex variant for the FormItem

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/form/FormItem.vue
+++ b/apps/v4/registry/new-york-v4/ui/form/FormItem.vue
@@ -1,12 +1,15 @@
 <script lang="ts" setup>
 import type { HTMLAttributes } from "vue"
+import type { FormItemVariants } from "."
 import { useId } from "reka-ui"
 import { provide } from "vue"
 import { cn } from "@/lib/utils"
+import { formItemVariants } from "."
 import { FORM_ITEM_INJECTION_KEY } from "./injectionKeys"
 
 const props = defineProps<{
   class?: HTMLAttributes["class"]
+  variant?: FormItemVariants["variant"]
 }>()
 
 const id = useId()
@@ -16,7 +19,7 @@ provide(FORM_ITEM_INJECTION_KEY, id)
 <template>
   <div
     data-slot="form-item"
-    :class="cn('grid gap-2', props.class)"
+    :class="cn(formItemVariants({ variant }), props.class)"
   >
     <slot />
   </div>

--- a/apps/v4/registry/new-york-v4/ui/form/index.ts
+++ b/apps/v4/registry/new-york-v4/ui/form/index.ts
@@ -5,3 +5,22 @@ export { default as FormLabel } from "./FormLabel.vue"
 export { default as FormMessage } from "./FormMessage.vue"
 export { FORM_ITEM_INJECTION_KEY } from "./injectionKeys"
 export { Form, Field as FormField, FieldArray as FormFieldArray } from "vee-validate"
+import type { VariantProps } from "class-variance-authority"
+import { cva } from "class-variance-authority"
+
+export const formItemVariants = cva(
+  "gap-2",
+  {
+    variants: {
+      variant: {
+        default: "grid",
+        flex: "flex",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+)
+
+export type FormItemVariants = VariantProps<typeof formItemVariants>


### PR DESCRIPTION


<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Add a flex variant for the FormItem component, as alternative to the default grid layout.
Makes the flex css usable without bother of overwriting the grid class.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Do we need to update the docs for this small change?
