### PR TITLE
fix(resizable-panel): expose splitterPanel ref

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/resizable/ResizablePanel.vue
+++ b/apps/v4/registry/new-york-v4/ui/resizable/ResizablePanel.vue
@@ -1,19 +1,33 @@
 <script setup lang="ts">
 import type { SplitterPanelEmits, SplitterPanelProps } from "reka-ui"
-import { SplitterPanel, useForwardExpose, useForwardPropsEmits } from "reka-ui"
+import { SplitterPanel, useForwardPropsEmits } from "reka-ui"
 
 const props = defineProps<SplitterPanelProps>()
 const emits = defineEmits<SplitterPanelEmits>()
 
 const forwarded = useForwardPropsEmits(props, emits)
-useForwardExpose()
+const SplitterPanelRef = useTemplateRef<InstanceType<typeof SplitterPanel>>("SplitterPanelRef")
+
+defineExpose({
+  collapse: () => SplitterPanelRef.value?.collapse(),
+  expand: () => SplitterPanelRef.value?.expand(),
+  getSize: () => SplitterPanelRef.value?.getSize(),
+  resize: (size: number) => SplitterPanelRef.value?.resize(size),
+  get isCollapsed() {
+    return SplitterPanelRef.value?.isCollapsed
+  },
+  get isExpanded() {
+    return SplitterPanelRef.value?.isExpanded
+  },
+})
 </script>
 
 <template>
   <SplitterPanel
     v-slot="slotProps"
-    data-slot="resizable-panel"
     v-bind="forwarded"
+    ref="SplitterPanelRef"
+    data-slot="resizable-panel"
   >
     <slot v-bind="slotProps" />
   </SplitterPanel>


### PR DESCRIPTION
fix #1284 

Previously, `useForwardExpose` was used here. This function only exposes `#el` and `props`. It doesn't extend the `defineExpose` of the `reka-ui - SplitterPanel` component further out.

Also, I'd like to ask, shouldn't the main code for `useForwardExpose` look like [this](https://github.com/vuejs/rfcs/issues/258#issuecomment-1068697672)?