### PR TITLE
fix: Tags Input TagsInputItemText default slot not being passed through to reka-ui

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/tags-input/TagsInputItemText.vue
+++ b/apps/v4/registry/new-york-v4/ui/tags-input/TagsInputItemText.vue
@@ -13,5 +13,7 @@ const forwardedProps = useForwardProps(delegatedProps)
 </script>
 
 <template>
-  <TagsInputItemText v-bind="forwardedProps" :class="cn('py-0.5 px-2 text-sm rounded bg-transparent', props.class)" />
+  <TagsInputItemText v-bind="forwardedProps" :class="cn('py-0.5 px-2 text-sm rounded bg-transparent', props.class)">
+    <slot />
+  </TagsInputItemText>
 </template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
I passed through the default slot for TagsInputItemText to the reka-ui component to allow for custom data display.
With this change object arrays may be used for Tags Input, instead of just string arrays.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
