### PR TITLE
chore(vscode): sort uppercase files first in explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,5 +48,6 @@
   "tailwindCSS.classFunctions": ["cva", "cn"],
   "files.exclude": {
     "deprecated": true
-  }
+  },
+  "explorer.sortOrderLexicographicOptions": "upper"
 }


### PR DESCRIPTION
To maintain the same sorting as GitHub files and prevent different results from running `pnpm registry:build-only` locally in VS Code.
**github**<img width="1228" height="445" alt="image" src="https://github.com/user-attachments/assets/65fc1732-7f8c-40a2-a533-9677670d5177" />
**vscode no set**
<img width="965" height="646" alt="image" src="https://github.com/user-attachments/assets/fe48fc05-3cc7-4780-8102-c8e5a457a9ce" />
**vscode already set**
<img width="1175" height="878" alt="image" src="https://github.com/user-attachments/assets/b6ed9717-09f8-4a0b-a2c5-e397b79356c4" />

