### PR TITLE
docs: remove nuxt tailwind from dark mode page

### DIFF
--- a/apps/v4/content/docs/dark-mode/02.nuxt.md
+++ b/apps/v4/content/docs/dark-mode/02.nuxt.md
@@ -18,7 +18,7 @@ Then, add `@nuxtjs/color-mode` to the modules section of your `nuxt.config.ts`
 ```ts
 export default defineNuxtConfig({
   modules: [
-    '@nuxtjs/tailwindcss',
+    'shadcn-nuxt',
     '@nuxtjs/color-mode'
   ],
   colorMode: {

--- a/apps/v4/content/docs/dark-mode/02.nuxt.md
+++ b/apps/v4/content/docs/dark-mode/02.nuxt.md
@@ -18,7 +18,7 @@ Then, add `@nuxtjs/color-mode` to the modules section of your `nuxt.config.ts`
 ```ts
 export default defineNuxtConfig({
   modules: [
-    'shadcn-nuxt',
+    '...',
     '@nuxtjs/color-mode'
   ],
   colorMode: {


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

https://github.com/unovue/shadcn-vue/issues/1654

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #1654 

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated dark mode setup guidance for Nuxt projects to reflect the current recommended configuration approach and improve clarity for developers migrating or configuring themes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->