### PR TITLE
fix(components): prevent form submit on NotionPromptForm buttons

### DIFF
--- a/apps/v4/components/examples/NotionPromptForm.vue
+++ b/apps/v4/components/examples/NotionPromptForm.vue
@@ -275,6 +275,7 @@ const hasMentions = computed(() => mentions.value.length > 0)
                 size="icon-sm"
                 class="rounded-full"
                 aria-label="Attach file"
+                type="button"
               >
                 <IconPaperclip />
               </InputGroupButton>
@@ -427,6 +428,7 @@ const hasMentions = computed(() => mentions.value.length > 0)
             class="ml-auto rounded-full"
             variant="default"
             size="icon-sm"
+            type="button"
           >
             <IconArrowUp />
           </InputGroupButton>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->
# fix(components): prevent form submit on NotionPromptForm buttons

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
No linked issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added `type="button"` to two `InputGroupButton` components in `NotionPromptForm.vue` to prevent unintended form submission, which was causing a full page reload and color flicker. This improves UX and prevents unwanted redirects.

### 📸 Screenshots / Video

#### Before
- Clicking the buttons caused a full page render, resulting in a color change and a bad UX.

https://github.com/user-attachments/assets/291c7c8d-f747-4f14-9b57-f222940afa88

#### After
- No page reload, no color flicker, and a smooth, good UX.

https://github.com/user-attachments/assets/a3803a75-c6ae-4244-859e-8433c04d0849

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button behavior in Notion Prompt Form to prevent unintended form submissions when clicking certain buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->