### PR TITLE
fix(cli): skip transform pipeline for non-code files (.md, .mdx, .txt)

### DIFF
--- a/packages/cli/src/utils/transformers/index.ts
+++ b/packages/cli/src/utils/transformers/index.ts
@@ -18,6 +18,14 @@ export interface TransformOpts {
 }
 
 export async function transform(opts: TransformOpts) {
+  // Skip the transform pipeline for non-code files.
+  // @babel/parser cannot parse formats like Markdown, and none of the
+  // codemods (import rewriting, CSS vars, Tailwind prefix, icons) are
+  // applicable to these files anyway.
+  const nonCodeExtensions = ['.md', '.mdx', '.txt']
+  if (nonCodeExtensions.some(ext => opts.filename.endsWith(ext)))
+    return opts.raw
+
   const source = await transformSFC(opts)
 
   const registryIcons = await getRegistryIcons()

--- a/packages/cli/test/utils/transform-sfc.test.ts
+++ b/packages/cli/test/utils/transform-sfc.test.ts
@@ -132,6 +132,36 @@ describe('transformSFC', () => {
     expect(result).toMatchSnapshot()
   })
 
+  it('returns raw content unchanged for .md files', async () => {
+    const raw = '---\nname: my-skill\ndescription: A Claude Code skill.\n---\n\n# Heading\n\nContent.\n'
+    const result = await transform({
+      filename: 'src/registry/skill/SKILL.md',
+      raw,
+      config: {},
+    })
+    expect(result).toBe(raw)
+  })
+
+  it('returns raw content unchanged for .mdx files', async () => {
+    const raw = '---\ntitle: My Doc\n---\n\n# Heading\n'
+    const result = await transform({
+      filename: 'src/registry/docs/README.mdx',
+      raw,
+      config: {},
+    })
+    expect(result).toBe(raw)
+  })
+
+  it('returns raw content unchanged for .txt files', async () => {
+    const raw = 'just some plain text\nno code here\n'
+    const result = await transform({
+      filename: 'src/registry/notes/NOTES.txt',
+      raw,
+      config: {},
+    })
+    expect(result).toBe(raw)
+  })
+
   it('defineEmits', async () => {
     const result = await transform({
       filename: 'app.vue',


### PR DESCRIPTION
Closes #1729

## Summary

- Added an early-return guard in `packages/cli/src/utils/transformers/index.ts` that returns `opts.raw` unchanged for `.md`, `.mdx`, and `.txt` files
- Both `transformSFC` and `vue-metamorph`'s `metaTransform` route non-`.vue` files through `@babel/parser`, which cannot parse Markdown YAML front matter — causing an `Unexpected token (2:4)` crash when a `registry:file` item targets a `.md` file
- None of the codemods (import rewriting, CSS vars, Tailwind prefix, icons) are applicable to these file types anyway

## Test plan

- [x] Added 3 new tests in `packages/cli/test/utils/transform-sfc.test.ts` covering `.md`, `.mdx`, and `.txt` passthrough
- [x] All 207 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-code files (Markdown, MDX, TXT) now bypass the transformation pipeline and are returned unchanged, preventing unnecessary processing.

* **Tests**
  * Added test coverage to verify non-code files are handled correctly without modification across all supported file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->