### PR TITLE
fix(alert): remove grid layout from AlertDescription that breaks inline content

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/alert/AlertDescription.vue
+++ b/apps/v4/registry/new-york-v4/ui/alert/AlertDescription.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 <template>
   <div
     data-slot="alert-description"
-    :class="cn('text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed', props.class)"
+    :class="cn('text-muted-foreground col-start-2 text-sm [&_p]:leading-relaxed', props.class)"
   >
     <slot />
   </div>


### PR DESCRIPTION
## Summary

The `grid justify-items-start gap-1` classes on `AlertDescription` (new-york-v4 style) force all children into separate grid rows, breaking inline text flow.

**Before (broken):**
```
Welcome!
You are viewing this as a guest.
Sign in
or
Sign up
to create compositions and more.
```

**After (fixed):**
```
Welcome!
You are viewing this as a guest.
Sign in or Sign up to create compositions and more.
```

## Change

Removes `grid justify-items-start gap-1` from the AlertDescription class list in `new-york-v4` style, keeping the existing text styling intact.

This only affects `AlertDescription` when it contains inline content (text, links). Block-level children (like `<p>` tags) are unaffected since they naturally stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual layout of alert descriptions by adjusting spacing and layout properties while maintaining typography and positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->