### PR TITLE
fix(ci): use pnpm pack to resolve catalog: protocol before npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,19 @@ jobs:
         run: npm install -g npm@^11
 
       - name: Build CLI & Publish to npm
-        run: pnpm --filter shadcn-vue build && npm publish ./packages/cli --access public --provenance
+        working-directory: packages/cli
+        run: |
+          pnpm build
+          pnpm pack
+          TARBALL="shadcn-vue-$(node -p "require('./package.json').version").tgz"
+          test -f "$TARBALL" || { echo "Tarball not found"; exit 1; }
+          npm publish "$TARBALL" --access public --provenance
 
       - name: Build Module & Publish to npm
-        run: pnpm --filter shadcn-nuxt prepack && npm publish ./packages/module --access public --provenance
+        working-directory: packages/module
+        run: |
+          pnpm prepack
+          pnpm pack
+          TARBALL="shadcn-nuxt-$(node -p "require('./package.json').version").tgz"
+          test -f "$TARBALL" || { echo "Tarball not found"; exit 1; }
+          npm publish "$TARBALL" --access public --provenance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,6 @@ jobs:
       - name: Build Module & Publish to npm
         working-directory: packages/module
         run: |
-          pnpm prepack
           pnpm pack
           TARBALL="shadcn-nuxt-$(node -p "require('./package.json').version").tgz"
           test -f "$TARBALL" || { echo "Tarball not found"; exit 1; }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1751

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

The v2.5.0 release is broken for all package managers (npm, pnpm, yarn, bun). Installing `shadcn-vue@2.5.0` fails with errors like:

```
npm error Unsupported URL Type "catalog:": catalog:
ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER "open@catalog:" isn't supported by any available resolver.
```

**Root cause:** Commit `41b2d26` ("ci: trusted publisher") changed the publish command from `pnpm publish` to `npm publish` to support Trusted Publishers / provenance signing. However, `npm publish` doesn't understand pnpm's `catalog:` workspace protocol, so dependencies like `open`, `pathe`, `reka-ui`, `tinyglobby`, `validate-npm-package-name`, and `zod` were published with unresolved `catalog:` specifiers.

Comparing the published packages confirms this:
- `shadcn-vue@2.4.3` (published via `pnpm publish`): all dependencies resolved correctly (e.g. `"zod": "^3.25.76"`)
- `shadcn-vue@2.5.0` (published via `npm publish`): dependencies left as `"zod": "catalog:"`

**Fix:** Use `pnpm pack` to create the tarball (which correctly resolves `catalog:` to concrete versions from `pnpm-workspace.yaml`), then `npm publish` the tarball to preserve Trusted Publisher / provenance signing. This applies to both the CLI and Module packages.

### 📝 Checklist

- [x] I have linked an issue or discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to build and package individual modules as tarballs and publish those artifacts. This streamlines and standardizes the publishing process, adds package artifact verification before publication, and reduces variability during releases for more reliable and reproducible package distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->