### PR TITLE
fix(cli): resolve multiple tsconfig alias prefixes correctly

### DIFF
--- a/packages/cli/src/registry/utils.ts
+++ b/packages/cli/src/registry/utils.ts
@@ -122,8 +122,10 @@ export async function recursivelyResolveFileImports(
     const moduleSpecifier = importStatement.getModuleSpecifierValue()
 
     const isRelativeImport = moduleSpecifier.startsWith(".")
-    const isAliasImport = moduleSpecifier.startsWith(
-      `${projectInfo.aliasPrefix}/`,
+    const aliasPrefixes = Object.keys(tsConfig.config.compilerOptions?.paths ?? {})
+      .map(key => key.replace(/\/\*$/, ""))
+    const isAliasImport = aliasPrefixes.some(
+      prefix => moduleSpecifier === prefix || moduleSpecifier.startsWith(`${prefix}/`),
     )
 
     // If not a local import, add to the dependencies array.

--- a/packages/cli/src/utils/resolve-import.ts
+++ b/packages/cli/src/utils/resolve-import.ts
@@ -1,5 +1,6 @@
 import type { TsConfigResult } from 'get-tsconfig'
 import { createPathsMatcher } from 'get-tsconfig'
+import path from 'pathe'
 
 export function resolveImport(importPath: string, config: TsConfigResult) {
   const matcher = createPathsMatcher(config)
@@ -7,5 +8,25 @@ export function resolveImport(importPath: string, config: TsConfigResult) {
     return
   }
   const paths = matcher(importPath)
-  return paths[0]
+  if (paths[0]) {
+    return paths[0]
+  }
+
+  // Handle the case where importPath exactly matches an alias prefix without
+  // a trailing path segment. e.g., "@components" should resolve when the
+  // tsconfig has "@components/*": ["./src/components/*"].
+  const tsconfigPaths = config.config.compilerOptions?.paths ?? {}
+  const baseUrl = config.config.compilerOptions?.baseUrl ?? '.'
+  const configDir = path.dirname(config.path)
+  const resolvedBaseUrl = path.resolve(configDir, baseUrl)
+
+  for (const [pattern, mappings] of Object.entries(tsconfigPaths)) {
+    const cleanPattern = pattern.replace(/\/\*$/, '')
+    if (cleanPattern === importPath && Array.isArray(mappings) && mappings.length > 0) {
+      const mapping = String(mappings[0]).replace(/\/\*$/, '')
+      return path.resolve(resolvedBaseUrl, mapping)
+    }
+  }
+
+  return undefined
 }


### PR DESCRIPTION
## Summary

Fixes #1744

- **`registry/utils.ts`**: `isAliasImport` previously only checked the single detected `aliasPrefix` (e.g. `@`). Imports using other configured aliases like `@components/button` or `@ui/card` were misidentified as external npm packages. The fix derives all alias prefixes from tsconfig `compilerOptions.paths` and checks the module specifier against all of them.

- **`resolve-import.ts`**: `resolveImport('@components', tsConfig)` would fail to match because `@components` has no trailing path segment to satisfy the `@components/*` wildcard. Added a fallback that strips `/*` from both the pattern and mapping to resolve bare alias prefix imports to their base directory.

## Test plan

- [ ] Configure multiple tsconfig aliases (`@`, `@components`, `@ui`, `@util`)
- [ ] Set `components.json` aliases to use non-`@` prefixes (e.g. `"components": "@components"`, `"ui": "@ui"`)
- [ ] Run `pnpm dlx shadcn-vue@latest add button` and confirm `resolvedPaths` are correct (not `/project/@components` but `/project/src/components`)
- [ ] Confirm imports in installed components using `@ui/...` are resolved as local files, not external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of TypeScript path aliases by deriving them from project configuration
  * Enhanced import resolution with fallback logic to reliably resolve imports when primary methods don't yield results
  * Fixed edge cases in import resolution that could return undefined values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->