### PR TITLE
fix(icons): add remixicon mappings and handle lucide v1.x Icon suffix

### DIFF
--- a/apps/v4/public/r/icons/index.json
+++ b/apps/v4/public/r/icons/index.json
@@ -3,222 +3,259 @@
     "lucide": "AlertCircle",
     "radix": "ExclamationTriangleIcon",
     "tabler": "IconExclamationCircle",
-    "phosphor": "PhWarningCircle"
+    "phosphor": "PhWarningCircle",
+    "remixicon": "RiAlertLine"
   },
   "ArrowLeft": {
     "lucide": "ArrowLeft",
     "radix": "ArrowLeftIcon",
     "tabler": "IconArrowLeft",
-    "phosphor": "PhArrowLeft"
+    "phosphor": "PhArrowLeft",
+    "remixicon": "RiArrowLeftLine"
   },
   "ArrowRight": {
     "lucide": "ArrowRight",
     "radix": "ArrowRightIcon",
     "tabler": "IconArrowRight",
-    "phosphor": "PhArrowRight"
+    "phosphor": "PhArrowRight",
+    "remixicon": "RiArrowRightLine"
   },
   "ArrowUpDown": {
     "lucide": "ArrowUpDown",
     "radix": "CaretSortIcon",
     "tabler": "IconArrowsSort",
-    "phosphor": "PhArrowsVertical"
+    "phosphor": "PhArrowsVertical",
+    "remixicon": "RiArrowUpDownLine"
   },
   "BellRing": {
     "lucide": "BellRing",
     "radix": "BellIcon",
     "tabler": "IconBellRinging",
-    "phosphor": "PhBellRinging"
+    "phosphor": "PhBellRinging",
+    "remixicon": "RiBellLine"
   },
   "Bold": {
     "lucide": "Bold",
     "radix": "FontBoldIcon",
     "tabler": "IconBold",
-    "phosphor": "PhTextB"
+    "phosphor": "PhTextB",
+    "remixicon": "RiBold"
   },
   "Calculator": {
     "lucide": "Calculator",
     "radix": "ComponentPlaceholderIcon",
     "tabler": "IconCalculator",
-    "phosphor": "PhCalculator"
+    "phosphor": "PhCalculator",
+    "remixicon": "RiCalculatorLine"
   },
   "Calendar": {
     "lucide": "Calendar",
     "radix": "CalendarIcon",
     "tabler": "IconCalendar",
-    "phosphor": "PhCalendarBlank"
+    "phosphor": "PhCalendarBlank",
+    "remixicon": "RiCalendarLine"
   },
   "Check": {
     "lucide": "Check",
     "radix": "CheckIcon",
     "tabler": "IconCheck",
-    "phosphor": "PhCheck"
+    "phosphor": "PhCheck",
+    "remixicon": "RiCheckLine"
   },
   "ChevronDown": {
     "lucide": "ChevronDown",
     "radix": "ChevronDownIcon",
     "tabler": "IconChevronDown",
-    "phosphor": "PhCaretDown"
+    "phosphor": "PhCaretDown",
+    "remixicon": "RiArrowDownSLine"
   },
   "ChevronLeft": {
     "lucide": "ChevronLeft",
     "radix": "ChevronLeftIcon",
     "tabler": "IconChevronLeft",
-    "phosphor": "PhCaretLeft"
+    "phosphor": "PhCaretLeft",
+    "remixicon": "RiArrowLeftSLine"
   },
   "ChevronRight": {
     "lucide": "ChevronRight",
     "radix": "ChevronRightIcon",
     "tabler": "IconChevronRight",
-    "phosphor": "PhCaretRight"
+    "phosphor": "PhCaretRight",
+    "remixicon": "RiArrowRightSLine"
   },
   "ChevronUp": {
     "lucide": "ChevronUp",
     "radix": "ChevronUpIcon",
     "tabler": "IconChevronUp",
-    "phosphor": "PhCaretUp"
+    "phosphor": "PhCaretUp",
+    "remixicon": "RiArrowUpSLine"
   },
   "ChevronsUpDown": {
     "lucide": "ChevronsUpDown",
     "radix": "CaretSortIcon",
     "tabler": "IconSelector",
-    "phosphor": "PhCaretUpDown"
+    "phosphor": "PhCaretUpDown",
+    "remixicon": "RiExpandUpDownLine"
   },
   "Circle": {
     "lucide": "Circle",
     "radix": "DotFilledIcon",
     "tabler": "IconCircle",
-    "phosphor": "PhCircle"
+    "phosphor": "PhCircle",
+    "remixicon": "RiCircleLine"
   },
   "Copy": {
     "lucide": "Copy",
     "radix": "CopyIcon",
     "tabler": "IconCopy",
-    "phosphor": "PhCopy"
+    "phosphor": "PhCopy",
+    "remixicon": "RiFileCopyLine"
   },
   "CreditCard": {
     "lucide": "CreditCard",
     "radix": "ComponentPlaceholderIcon",
     "tabler": "IconCreditCard",
-    "phosphor": "PhCreditCard"
+    "phosphor": "PhCreditCard",
+    "remixicon": "RiBankCardLine"
   },
   "GripVertical": {
     "lucide": "GripVertical",
     "radix": "DragHandleDots2Icon",
     "tabler": "IconGripVertical",
-    "phosphor": "PhDotsSixVertical"
+    "phosphor": "PhDotsSixVertical",
+    "remixicon": "RiDraggable"
   },
   "Italic": {
     "lucide": "Italic",
     "radix": "FontItalicIcon",
     "tabler": "IconItalic",
-    "phosphor": "PhTextItalic"
+    "phosphor": "PhTextItalic",
+    "remixicon": "RiItalic"
   },
   "Loader2": {
     "lucide": "Loader2",
     "radix": "ReloadIcon",
     "tabler": "IconLoader2",
-    "phosphor": "PhCircleNotch"
+    "phosphor": "PhCircleNotch",
+    "remixicon": "RiLoader4Line"
   },
   "Mail": {
     "lucide": "Mail",
     "radix": "EnvelopeClosedIcon",
     "tabler": "IconMail",
-    "phosphor": "PhEnvelopeSimple"
+    "phosphor": "PhEnvelopeSimple",
+    "remixicon": "RiMailLine"
   },
   "MailOpen": {
     "lucide": "MailOpen",
     "radix": "EnvelopeOpenIcon",
     "tabler": "IconMailOpened",
-    "phosphor": "PhEnvelopeSimpleOpen"
+    "phosphor": "PhEnvelopeSimpleOpen",
+    "remixicon": "RiMailOpenLine"
   },
   "Minus": {
     "lucide": "Minus",
     "radix": "MinusIcon",
     "tabler": "IconMinus",
-    "phosphor": "PhMinus"
+    "phosphor": "PhMinus",
+    "remixicon": "RiSubtractLine"
   },
   "Moon": {
     "lucide": "Moon",
     "radix": "MoonIcon",
     "tabler": "IconMoon",
-    "phosphor": "PhMoon"
+    "phosphor": "PhMoon",
+    "remixicon": "RiMoonLine"
   },
   "MoreHorizontal": {
     "lucide": "MoreHorizontal",
     "radix": "DotsHorizontalIcon",
     "tabler": "IconDots",
-    "phosphor": "PhDotsThree"
+    "phosphor": "PhDotsThree",
+    "remixicon": "RiMoreLine"
   },
   "PanelLeft": {
     "lucide": "PanelLeft",
     "radix": "ViewVerticalIcon",
     "tabler": "IconLayoutSidebar",
-    "phosphor": "PhSidebarSimple"
+    "phosphor": "PhSidebarSimple",
+    "remixicon": "RiSideBarLine"
   },
   "Plus": {
     "lucide": "Plus",
     "radix": "PlusIcon",
     "tabler": "IconPlus",
-    "phosphor": "PhPlus"
+    "phosphor": "PhPlus",
+    "remixicon": "RiAddLine"
   },
   "Search": {
     "lucide": "Search",
     "radix": "MagnifyingGlassIcon",
     "tabler": "IconSearch",
-    "phosphor": "PhMagnifyingGlass"
+    "phosphor": "PhMagnifyingGlass",
+    "remixicon": "RiSearchLine"
   },
   "Send": {
     "lucide": "Send",
     "radix": "PaperPlaneIcon",
     "tabler": "IconSend",
-    "phosphor": "PhPaperPlaneTilt"
+    "phosphor": "PhPaperPlaneTilt",
+    "remixicon": "RiSendPlaneLine"
   },
   "Settings": {
     "lucide": "Settings",
     "radix": "GearIcon",
     "tabler": "IconSettings",
-    "phosphor": "PhGear"
+    "phosphor": "PhGear",
+    "remixicon": "RiSettingsLine"
   },
   "Slash": {
     "lucide": "Slash",
     "radix": "SlashIcon",
     "tabler": "IconSlash",
-    "phosphor": "PhCaretRight"
+    "phosphor": "PhCaretRight",
+    "remixicon": "RiSlashCommands"
   },
   "Smile": {
     "lucide": "Smile",
     "radix": "FaceIcon",
     "tabler": "IconMoodSmile",
-    "phosphor": "PhSmiley"
+    "phosphor": "PhSmiley",
+    "remixicon": "RiEmotionLine"
   },
   "Sun": {
     "lucide": "Sun",
     "radix": "SunIcon",
     "tabler": "IconSun",
-    "phosphor": "PhSun"
+    "phosphor": "PhSun",
+    "remixicon": "RiSunLine"
   },
   "Terminal": {
     "lucide": "Terminal",
     "radix": "RocketIcon",
     "tabler": "IconTerminal",
-    "phosphor": "PhTerminal"
+    "phosphor": "PhTerminal",
+    "remixicon": "RiTerminalBoxLine"
   },
   "Underline": {
     "lucide": "Underline",
     "radix": "UnderlineIcon",
     "tabler": "IconUnderline",
-    "phosphor": "PhTextUnderline"
+    "phosphor": "PhTextUnderline",
+    "remixicon": "RiUnderline"
   },
   "User": {
     "lucide": "User",
     "radix": "PersonIcon",
     "tabler": "IconUser",
-    "phosphor": "PhUser"
+    "phosphor": "PhUser",
+    "remixicon": "RiUserLine"
   },
   "X": {
     "lucide": "X",
     "radix": "Cross2Icon",
     "tabler": "IconX",
-    "phosphor": "PhX"
+    "phosphor": "PhX",
+    "remixicon": "RiCloseLine"
   }
 }

--- a/packages/cli/src/utils/transformers/transform-icons.ts
+++ b/packages/cli/src/utils/transformers/transform-icons.ts
@@ -48,7 +48,10 @@ export function transformIcons(opts: TransformOpts, registryIcons: Record<string
             for (const specifier of path.node.specifiers ?? []) {
               if (specifier.type === 'ImportSpecifier') {
                 const iconName = specifier.imported.name
+                // Try exact match first, then strip lucide v1.x `Icon` suffix
+                // so that e.g. `ChevronDownIcon` resolves via the `ChevronDown` entry.
                 const targetedIcon = registryIcons[iconName]?.[targetLibrary]
+                  ?? registryIcons[iconName.replace(/Icon$/, '')]?.[targetLibrary]
 
                 if (!targetedIcon || targetedIconsMap.has(iconName)) {
                   continue

--- a/packages/cli/test/utils/transform-icons.test.ts
+++ b/packages/cli/test/utils/transform-icons.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { transform as metaTransform } from 'vue-metamorph'
 import { transform } from '../../src/utils/transformers'
+import { transformIcons } from '../../src/utils/transformers/transform-icons'
 
 describe('transformIcons', () => {
   it('transforms phosphor icons', async () => {
@@ -80,6 +82,60 @@ describe('transformIcons', () => {
       },
     })
     expect(result).toMatchSnapshot()
+  })
+
+  it('transforms icons with Icon suffix via fallback', async () => {
+    const result = await transform({
+      filename: 'app.vue',
+      raw: `<script lang="ts" setup>
+      import { CheckIcon } from 'lucide-vue-next'
+      import { Primitive } from 'reka-ui'
+      </script>
+
+      <template>
+        <CheckIcon />
+        <Primitive />
+      </template>
+      `,
+      config: {
+        iconLibrary: 'phosphor',
+      },
+    })
+    expect(result).toContain('@phosphor-icons/vue')
+    expect(result).toContain('PhCheck')
+    expect(result).not.toContain('lucide-vue-next')
+    expect(result).not.toContain('CheckIcon')
+  })
+
+  it('transforms remixicon icons with Icon suffix via fallback', async () => {
+    const registryIcons = {
+      Check: { remixicon: 'RiCheckLine' },
+      ChevronDown: { remixicon: 'RiArrowDownSLine' },
+    }
+    const source = `<script lang="ts" setup>
+import { CheckIcon, ChevronDownIcon } from 'lucide-vue-next'
+import { Primitive } from 'reka-ui'
+</script>
+
+<template>
+  <CheckIcon />
+  <ChevronDownIcon />
+  <Primitive />
+</template>
+`
+    const result = metaTransform(source, 'app.vue', [
+      transformIcons(
+        { filename: 'app.vue', raw: source, config: { iconLibrary: 'remixicon' } },
+        registryIcons,
+      ),
+    ]).code
+
+    expect(result).toContain('@remixicon/vue')
+    expect(result).toContain('RiCheckLine')
+    expect(result).toContain('RiArrowDownSLine')
+    expect(result).not.toContain('lucide-vue-next')
+    expect(result).not.toContain('CheckIcon')
+    expect(result).not.toContain('ChevronDownIcon')
   })
 
   it('does nothing', async () => {


### PR DESCRIPTION
## Summary

Fixes #1770 — CLI ignores `iconLibrary: "remixicon"` config and generates `lucide-vue-next` imports regardless.

**Root cause (two problems):**

1. `icons/index.json` had no `remixicon` entries at all, so the transform could never find a target icon
2. v4 (reka-lyra) components use lucide v1.x naming with `Icon` suffix (e.g. `ChevronDownIcon`) but the registry only had non-suffixed keys (`ChevronDown`), so the lookup missed for ALL non-lucide libraries in v4 components

**Fix:**

- **`transform-icons.ts`** — when exact lookup fails, strip the `Icon` suffix and retry. This lets `ChevronDownIcon` resolve via the existing `ChevronDown` entry without duplicating every registry entry.
- **`icons/index.json`** — add `remixicon` mapping to all 37 existing entries.

Remixicon names cross-referenced against `<IconPlaceholder>` attributes in `apps/v4/registry/bases/reka/ui/**.vue` where available.

## Test plan

- [ ] Configure `"iconLibrary": "remixicon"` in `components.json`
- [ ] Run `npx shadcn-vue@latest add select checkbox`
- [ ] Verify generated components import from `@remixicon/vue` (e.g. `RiArrowDownSLine`, `RiCheckLine`)
- [ ] Verify existing lucide/tabler/phosphor/radix substitution still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RemixIcon mappings to the icon catalog, expanding available icon options.

* **Bug Fixes**
  * Improved icon name resolution to correctly handle imports using an "Icon" suffix and similar naming variants.

* **Tests**
  * Added tests validating transformation and mapping of icon imports (including "Icon" suffix cases and RemixIcon mapping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->